### PR TITLE
feat(agent-todos): Obsidian as configurable primary todo store (v0.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "agent-todos",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "source": "./plugins/agent-todos",
       "description": "Agent todo file management skills"
     },

--- a/docs/agent-todos/TODO_OVERVIEW.md
+++ b/docs/agent-todos/TODO_OVERVIEW.md
@@ -1,6 +1,6 @@
 # Todo Overview
 
-Generated on 2026-02-25 06:06:21 CET.
+Generated on 2026-02-25 06:39:38 CET.
 
 ## Todo Kanban
 
@@ -13,10 +13,9 @@ kanban
     ideas-0001[Image Manipulation Skill with SIPs]@{ ticket: ideas-0001 }
     ideas-0002[Dev Toys CLI Skill]@{ ticket: ideas-0002 }
     ideas-0003[Skill to Search Skillsmp]@{ ticket: ideas-0003 }
-    plugin-agent-todos-0015[Obsidian as primary todo store]@{ ticket: plugin-agent-todos-0015 }
     plugin-hugo-blog-0001[Hugo markdown linting skill]@{ ticket: plugin-hugo-blog-0001 }
   doing[Doing]
-
+    plugin-agent-todos-0015[Obsidian as primary todo store]@{ ticket: plugin-agent-todos-0015 }
   done[Done]
     common-0001[Describe plugins in readme]@{ ticket: common-0001 }
     common-0002[describe obsidian import in readme]@{ ticket: common-0002 }
@@ -49,7 +48,7 @@ kanban
 | ideas | [Image Manipulation Skill with SIPs](/docs/agent-todos/ideas/0001_image_manipulation_skill_with_sips.md) | ready |
 | ideas | [Dev Toys CLI Skill](/docs/agent-todos/ideas/0002_dev_toys_cli_skill.md) | ready |
 | ideas | [Skill to Search Skillsmp](/docs/agent-todos/ideas/0003_skill_to_search_skillsmp.md) | ready |
-| plugin-agent-todos | [Obsidian as primary todo store](/docs/agent-todos/plugin-agent-todos/0015_obsidian_as_primary_todo_store.md) | ready |
+| plugin-agent-todos | [Obsidian as primary todo store](/docs/agent-todos/plugin-agent-todos/0015_obsidian_as_primary_todo_store.md) | doing |
 | plugin-agent-todos | [Change Todo Prefix To 4 Digits](/docs/agent-todos/plugin-agent-todos/DONE_0000_change_todo_prefix.md) | done |
 | plugin-agent-todos | [Error when installing Plugin](/docs/agent-todos/plugin-agent-todos/DONE_0001_error_when_installing.md) | done |
 | plugin-agent-todos | [Add status to todo](/docs/agent-todos/plugin-agent-todos/DONE_0002_add_status_to_todo.md) | done |

--- a/docs/agent-todos/plugin-agent-todos/0015_obsidian_as_primary_todo_store.md
+++ b/docs/agent-todos/plugin-agent-todos/0015_obsidian_as_primary_todo_store.md
@@ -1,16 +1,94 @@
 ---
-title: 'Obsidian as primary todo store'
-status: ready
+title: "Obsidian as primary todo store"
+status: done
 ---
 
-## context
+## Context
 
-the storage of todos inside the codebase docs folder works fine for my private projects a i work alone in them. at work the acceptance of working with ai agents, is not as highly adapted  as would wish. So having a /docs/agent-todos folder in the codebase is not accepted. 
+The storage of todos inside the codebase docs folder works fine for private projects where working alone. At work, the acceptance of working with AI agents is not as highly adapted. Having a `/docs/agent-todos` folder in the codebase is not accepted.
 
-we need to have an optional workflow where obsidian becomes the store (and not only an import source) for the todos. i think of still having the agent-todos folder in obsidian with sub folder that reflect the project. But inside those folder we would need the category folders
+An optional workflow is needed where Obsidian becomes the store (not only an import source) for the todos. The agent-todos folder would remain in Obsidian with subfolders reflecting the project, and inside those folders the category folders would be used.
 
-## tasks
+## Tasks
 
-- plan before you implement anything
-- find out which skills an scripts we would have to modify to do so
-- would it be better we use obsidian in general as the todo store ?
+- [x] Plan before implementing anything
+- [x] Find out which skills and scripts would need to be modified
+- [x] Decide: full Obsidian-primary mode vs. configurable store path → Option A (configurable)
+- [x] Add configuration mechanism (plugin settings)
+- [x] Parameterize `create-todo.sh`, `update-overview.sh`, `move-todos.sh`
+- [x] Replace `todo-overview` with Obsidian Kanban board when store is Obsidian
+- [x] Update all SKILL.md documentation
+- [x] Add `todo-migrate-to-obsidian` skill (moves docs/agent-todos → Obsidian vault)
+
+## Progress, Decisions etc.
+
+### 2026-02-25: Analysis — Skills and Scripts That Must Change
+
+**Problem restatement:**
+At work, placing `docs/agent-todos/` inside a codebase is not acceptable. Obsidian (iCloud-synced) should become the primary store, not just an import source.
+
+**Current data flow (as-is):**
+
+```
+Obsidian vault/agent-todos/<project>/ → (import) → docs/agent-todos/<user-chosen-category>/
+```
+
+Obsidian is currently read-only/source only. All skills write to `docs/agent-todos/`. The source path uses `<project>` as the subfolder (not category); the user chooses the destination category at import time.
+
+**Scripts with hardcoded paths — must be changed:**
+
+| Script               | Hardcoded line | Path                                   |
+| -------------------- | -------------- | -------------------------------------- |
+| `create-todo.sh`     | Line 26        | `$BASE_DIR/docs/agent-todos/$CATEGORY` |
+| `update-overview.sh` | Lines 5–6      | `$PROJECT_ROOT/docs/agent-todos`       |
+| `move-todos.sh`      | Line 15        | `$PROJECT_ROOT/docs/agent-todos`       |
+
+**Skills with hardcoded documentation references — need doc updates:**
+All 7 SKILL.md files reference `docs/agent-todos/` in descriptions and examples.
+
+**Two design options:**
+
+**Option A — Configurable store path (recommended)**
+
+- Add `agent-todos-root` to plugin settings (`.claude/agent-todos.local.md` frontmatter)
+- Scripts read config, fall back to `docs/agent-todos/`
+- Obsidian path would be something like `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault>/agent-todos/`
+- Both modes co-exist; users choose per-project
+- No breaking changes for existing users
+
+**Option B — Obsidian-only mode**
+
+- Replace all `docs/agent-todos/` with Obsidian vault path
+- Eliminates the codebase dependency entirely
+- Breaking change for all existing users
+- Overview file also lives in Obsidian
+
+**Recommendation:** Option A. Use the `plugin-dev:plugin-settings` pattern to add a configurable `todos-root` key. Scripts read this at runtime. When Obsidian is the primary store, all skills write directly to the vault path — no export mode needed. A dedicated `todo-migrate-to-obsidian` skill handles the one-time move of existing `docs/agent-todos/` content to the Obsidian vault for users switching stores.
+
+**Decisions:**
+
+- **Overview format:** `TODO_OVERVIEW.md` is not useful inside Obsidian. When the store is Obsidian, use an Obsidian Kanban board instead (see `plugins/obsidian/skills/obsidian-kanban`).
+- **GitHub issue close comment:** Still reference the file path — it will just point to the Obsidian vault path instead of `docs/agent-todos/`.
+- **Sync:** No bidirectional sync needed. Todos live in Obsidian only when Obsidian-primary mode is active.
+
+### 2026-02-25: Implementation Complete
+
+**What was done:**
+
+- Created `.claude/agent-todos.local.md` config pattern with `todos_root`, `vault_root`, `kanban_file` fields
+- Added `read_agent_todos_config()` + `_read_fm_key()` helper inline to all 3 scripts (self-contained, no shared script):
+  - `create-todo.sh`: replaced hardcoded `$BASE_DIR/docs/agent-todos/$CATEGORY` with `$TODOS_ROOT/$CATEGORY`
+  - `move-todos.sh`: replaced hardcoded `TODOS_ROOT` assignment with config reader
+  - `update-overview.sh`: added config reader + Obsidian Kanban generation branch
+- `update-overview.sh` now:
+  - In default mode: generates `TODO_OVERVIEW.md` with Mermaid Kanban + markdown table (unchanged behavior)
+  - In Obsidian mode (when `KANBAN_FILE` is set): generates Obsidian Kanban board file at `kanban_file` path with wiki links relative to `vault_root`
+- Added `todo-migrate-to-obsidian` skill:
+  - `SKILL.md`: 5-step workflow (gather input → run script → write config → run /todo-overview → ask about deletion)
+  - `scripts/migrate-to-obsidian.sh`: copies `docs/agent-todos/` to vault, prints config values to stdout
+- Updated all 7 SKILL.md files to reference "configured todos directory (default: `docs/agent-todos/`)"
+- Bumped `agent-todos` version `0.2.5` → `0.3.0` in `plugin.json` and `marketplace.json`
+
+**Architecture:**
+
+Config is read at script runtime via awk frontmatter parsing. `~` in paths is expanded to `$HOME`. Fallback to `docs/agent-todos/` when no config file exists — zero breaking changes for existing users.

--- a/docs/plugins/agent-todos.md
+++ b/docs/plugins/agent-todos.md
@@ -1,44 +1,97 @@
 # agent-todos
 
-`agent-todos` provides structured todo workflows for AI agents using markdown files under `docs/agent-todos/`.
+`agent-todos` provides structured todo workflows for AI agents. By default, todos are stored under `docs/agent-todos/` inside the project. For workplaces where committing AI task files is not acceptable, todos can be stored in an Obsidian vault instead — configured per project via `.claude/agent-todos.local.md`.
 
 ## What It Does
 
 - Standardizes todo file creation, naming, and frontmatter.
 - Guides agents through a status lifecycle (`new`, `ready`, `doing`, `done`, `archived`).
-- Generates project-level todo overviews and visual status boards.
+- Generates project-level todo overviews: Mermaid Kanban (default) or Obsidian Kanban board (Obsidian mode).
 - Moves open todos between categories and renumbers open items without colliding with DONE items.
 - Supports importing todos from GitHub issues and Obsidian/iCloud vaults.
+- Migrates an existing `docs/agent-todos/` to an Obsidian vault in one step.
 
 ## Skills
 
-| Skill                          | Description                                                                         |
-| ------------------------------ | ----------------------------------------------------------------------------------- |
-| `/todo-init`                   | Initializes the `docs/agent-todos/` folder structure with category subdirectories.  |
-| `/todo-creation`               | Creates a new todo file with sequential 4-digit numbering and YAML frontmatter.     |
-| `/todo-processing`             | Reference skill defining todo file conventions, naming, and progress tracking.      |
-| `/todo-overview`               | Generates or updates `docs/agent-todos/TODO_OVERVIEW.md` with Kanban + table views. |
-| `/todo-moving`                 | Moves selected open todos between categories and renumbers open todos in both folders. |
-| `/todo-gh-issue-import`        | Imports open GitHub issues into local todo files using `gh issue list`.             |
-| `/todo-obsidian-icloud-import` | Imports todos from a local Obsidian vault synced via iCloud Drive (macOS).          |
+| Skill | Description |
+| --- | --- |
+| `/todo-init` | Initializes the todos folder structure with category subdirectories. |
+| `/todo-creation` | Creates a new todo file with sequential 4-digit numbering and YAML frontmatter. |
+| `/todo-processing` | Reference skill defining todo file conventions, naming, and progress tracking. |
+| `/todo-overview` | Generates or updates the todo overview (Mermaid `TODO_OVERVIEW.md` or Obsidian Kanban board). |
+| `/todo-moving` | Moves selected open todos between categories and renumbers open todos in both folders. |
+| `/todo-gh-issue-import` | Imports open GitHub issues into local todo files using `gh issue list`. |
+| `/todo-obsidian-icloud-import` | Imports todos from a local Obsidian vault synced via iCloud Drive (macOS). |
+| `/todo-migrate-to-obsidian` | Copies `docs/agent-todos/` to an Obsidian vault and writes the config file (macOS). |
 
-## Obsidian Import Setup
+## Configuration
 
-The `/todo-obsidian-icloud-import` skill reads from an Obsidian vault synced via iCloud Drive. Create an `agent-todos/` directory in your vault:
+### Default (no configuration)
 
-```text
-<YourVault>/
-└── agent-todos/
-    └── <project-or-category>/
-        ├── 0001_some_task.md
-        └── 0002_another_task.md
+All skills read from and write to `docs/agent-todos/` inside the project root. No setup needed.
+
+### Obsidian mode
+
+Create `.claude/agent-todos.local.md` in the project root (this file is gitignored by Claude Code conventions):
+
+```markdown
+---
+todos_root: ~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault-name>/agent-todos/<project-name>
+vault_root: ~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault-name>
+kanban_file: ~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault-name>/agent-todos/<project-name>-kanban.md
+---
 ```
 
-On macOS, iCloud-backed Obsidian vaults are typically located at:
+| Field | Required | Description |
+| --- | --- | --- |
+| `todos_root` | yes | Absolute path to the todos root (holds category subdirectories). Replaces `docs/agent-todos/`. |
+| `vault_root` | no | Obsidian vault root. Used to compute wiki-link paths in the Kanban board. |
+| `kanban_file` | no | Obsidian Kanban output path. Defaults to `$(dirname todos_root)/$(basename todos_root)-kanban.md`. |
 
-```text
-~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault-name>/
+`~` in paths is expanded to `$HOME` at runtime.
+
+When `kanban_file` is set (or derived from a non-default `todos_root`), `/todo-overview` generates an Obsidian Kanban board file instead of `TODO_OVERVIEW.md`.
+
+### Switching back to default
+
+Delete `.claude/agent-todos.local.md`. All skills fall back to `docs/agent-todos/` immediately — no other changes needed.
+
+### Migrating existing todos to Obsidian
+
+Run `/todo-migrate-to-obsidian` to copy `docs/agent-todos/` to the vault and write the config file automatically. The skill also generates the initial Kanban board and optionally removes `docs/agent-todos/` from the codebase.
+
+## Obsidian Kanban output format
+
+When in Obsidian mode, `/todo-overview` generates a board compatible with the [Obsidian Kanban plugin](https://github.com/mgmeyers/obsidian-kanban):
+
+````markdown
+---
+kanban-plugin: board
+---
+
+## New
+- [ ] [[agent-todos/my-project/misc/0001_some_task|Some task]]
+
+## Ready
+- [ ] [[agent-todos/my-project/misc/0002_other_task|Other task]]
+
+## Doing
+
+## Done
+- [x] [[agent-todos/my-project/misc/DONE_0003_done_task|Done task]]
+
+***
+
+## Archive
+
+%% kanban:settings
+```json
+{"kanban-plugin":"board"}
 ```
+%%
+````
+
+Wiki-link paths are computed as the file path relative to `vault_root` with the `.md` extension stripped.
 
 ## Status Lifecycle
 

--- a/plugins/agent-todos/.claude-plugin/plugin.json
+++ b/plugins/agent-todos/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-todos",
   "description": "Agent todo file management skills",
-  "version": "0.2.5"
+  "version": "0.3.0"
 }

--- a/plugins/agent-todos/skills/todo-creation/SKILL.md
+++ b/plugins/agent-todos/skills/todo-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: todo-creation
-description: This skill should be used when the user asks to "create a todo", "add a todo", "new todo", "make a todo", "new task", "create a task", "add a task file", or wants to create a new agent todo file in docs/agent-todos/.
+description: This skill should be used when the user asks to "create a todo", "add a todo", "new todo", "make a todo", "new task", "create a task", "add a task file", or wants to create a new agent todo file in the configured todos directory (default: docs/agent-todos/).
 allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
 invocation: user
 argument-hint: "[category] [title]"
@@ -8,7 +8,7 @@ argument-hint: "[category] [title]"
 
 # todo-creation
 
-Create a new todo file in `docs/agent-todos/` with proper sequential numbering and YAML frontmatter.
+Create a new todo file in the configured todos directory (default: `docs/agent-todos/`) with proper sequential numbering and YAML frontmatter.
 
 ## Workflow
 
@@ -16,7 +16,7 @@ Create a new todo file in `docs/agent-todos/` with proper sequential numbering a
 
 Collect the category and title. These may come from skill arguments or by asking the user.
 
-- **Category** — The subdirectory name under `docs/agent-todos/` (e.g., `data`, `misc`, `agent-todos`). If the directory does not exist, it will be created.
+- **Category** — The subdirectory name under the todos directory (e.g., `data`, `misc`, `agent-todos`). If the directory does not exist, it will be created.
 - **Title** — A human-readable title for the todo (e.g., "Fix soft 404 errors").
 
 If both values are provided as arguments (e.g., `/todo-creation data Fix soft 404 errors`), parse the first word as the category and the rest as the title.
@@ -49,7 +49,7 @@ After the file is created, inform the user of the file path and ask them to add 
 
 ### 4. Update Overview
 
-After creating the todo (and again after switching `status` to `ready`), run `/todo-overview` to refresh `docs/agent-todos/TODO_OVERVIEW.md`.
+After creating the todo (and again after switching `status` to `ready`), run `/todo-overview` to refresh the todo overview.
 
 ## File Format
 
@@ -90,4 +90,4 @@ status: ready
 - If the category directory does not exist, it is created automatically.
 - The filename is truncated to 60 characters (before the `.md` extension) to keep paths manageable.
 - After the user adds content, update the status to `ready` so the todo is recognized as actionable under the conventions defined by `todo-processing`.
-- Keep `docs/agent-todos/TODO_OVERVIEW.md` in sync by invoking `/todo-overview` after creation and status updates.
+- Keep the todo overview in sync by invoking `/todo-overview` after creation and status updates.

--- a/plugins/agent-todos/skills/todo-creation/scripts/create-todo.sh
+++ b/plugins/agent-todos/skills/todo-creation/scripts/create-todo.sh
@@ -23,7 +23,37 @@ fi
 CATEGORY="$1"
 TITLE="$2"
 BASE_DIR="${3:-$PWD}"
-TODO_DIR="$BASE_DIR/docs/agent-todos/$CATEGORY"
+PROJECT_ROOT="$BASE_DIR"
+
+# ---------------------------------------------------------------------------
+# Agent-todos config reader
+# Reads .claude/agent-todos.local.md and sets TODOS_ROOT, VAULT_ROOT, KANBAN_FILE
+# ---------------------------------------------------------------------------
+_read_fm_key() {
+  awk -v k="$1" '
+    NR==1&&/^---$/{f=1;next}
+    f&&/^---$/{exit}
+    f&&$1==k":"{sub("^"k":[[:space:]]*","");gsub(/^"|"$/,"");gsub(/^\047|\047$/,"");print;exit}
+  ' "$2"
+}
+
+read_agent_todos_config() {
+  local config_file="$PROJECT_ROOT/.claude/agent-todos.local.md"
+  TODOS_ROOT="$PROJECT_ROOT/docs/agent-todos"
+  VAULT_ROOT=""
+  KANBAN_FILE=""
+  [ -f "$config_file" ] || return 0
+  local v
+  v="$(_read_fm_key todos_root "$config_file")";  [ -n "$v" ] && TODOS_ROOT="${v/#\~/$HOME}"
+  v="$(_read_fm_key vault_root "$config_file")";  [ -n "$v" ] && VAULT_ROOT="${v/#\~/$HOME}"
+  v="$(_read_fm_key kanban_file "$config_file")"; [ -n "$v" ] && KANBAN_FILE="${v/#\~/$HOME}"
+  if [ -z "$KANBAN_FILE" ] && [ "$TODOS_ROOT" != "$PROJECT_ROOT/docs/agent-todos" ]; then
+    KANBAN_FILE="$(dirname "$TODOS_ROOT")/$(basename "$TODOS_ROOT")-kanban.md"
+  fi
+}
+
+read_agent_todos_config
+TODO_DIR="$TODOS_ROOT/$CATEGORY"
 
 # Create category directory if it does not exist
 mkdir -p "$TODO_DIR"

--- a/plugins/agent-todos/skills/todo-gh-issue-import/SKILL.md
+++ b/plugins/agent-todos/skills/todo-gh-issue-import/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: todo-gh-issue-import
-description: Import open GitHub issues into local agent todo files. Use when the user asks to "import issues", "import from GitHub", "convert issues to todos", or wants to pull GitHub issues into the docs/agent-todos/ workflow.
+description: Import open GitHub issues into local agent todo files. Use when the user asks to "import issues", "import from GitHub", "convert issues to todos", or wants to pull GitHub issues into the configured todos directory (default: docs/agent-todos/).
 compatibility: Requires gh CLI (https://cli.github.com/)
 allowed-tools: Bash, Read, Write, Edit, Skill, AskUserQuestion
 invocation: user
@@ -9,7 +9,7 @@ argument-hint: "[category]"
 
 # todo-gh-issue-import
 
-Import open GitHub issues into local todo files using the `docs/agent-todos/` workflow.
+Import open GitHub issues into local todo files using the configured todos directory (default: `docs/agent-todos/`).
 
 ## Prerequisites
 
@@ -43,7 +43,7 @@ If there are no open issues, inform the user and stop.
 
 ### 3. Determine Category
 
-For each issue, determine the target category subdirectory under `docs/agent-todos/`:
+For each issue, determine the target category subdirectory under the todos directory:
 
 - If the issue has a label that matches an existing category directory, use that label
 - If a category argument was provided (e.g., `/todo-gh-issue-import data`), use it for all issues
@@ -91,11 +91,11 @@ Where `<file-path>` is the relative path like `docs/agent-todos/data/0042_fix_so
 
 ### 7. Update Overview
 
-After processing all issues (and closing them), run `/todo-overview` to refresh `docs/agent-todos/TODO_OVERVIEW.md`.
+After processing all issues (and closing them), run `/todo-overview` to refresh the todo overview.
 
 ## Example
 
-An imported issue #7 titled "Fix soft 404 errors" with label "data" becomes `docs/agent-todos/data/0042_fix_soft_404_errors.md`:
+An imported issue #7 titled "Fix soft 404 errors" with label "data" becomes `<todos-directory>/data/0042_fix_soft_404_errors.md`:
 
 ```markdown
 ---
@@ -112,7 +112,7 @@ status: ready
 - [ ] ...
 ```
 
-The GitHub issue is then closed with the comment: `Imported to docs/agent-todos/data/0042_fix_soft_404_errors.md`
+The GitHub issue is then closed with the comment: `Imported to <todos-directory>/data/0042_fix_soft_404_errors.md`
 
 ## Notes
 
@@ -121,4 +121,4 @@ The GitHub issue is then closed with the comment: `Imported to docs/agent-todos/
 - Imported todos always get `status: ready` since they already have content from the issue
 - The `/todo-creation` skill handles sequential numbering and file naming conventions
 - If `gh` is not authenticated, the user will see an auth error — direct them to run `gh auth login`
-- Keep `docs/agent-todos/TODO_OVERVIEW.md` in sync by invoking `/todo-overview` after imports.
+- Keep the todo overview in sync by invoking `/todo-overview` after imports.

--- a/plugins/agent-todos/skills/todo-init/SKILL.md
+++ b/plugins/agent-todos/skills/todo-init/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: todo-init
-description: Initialize the docs/agent-todos folder structure
+description: Initialize the docs/agent-todos folder structure (or the configured todos directory)
 allowed-tools: Bash, Read, Write, AskUserQuestion
 invocation: user
 ---
 
 # todo-init
 
-Initialize the `docs/agent-todos/` folder structure for AI agent task tracking.
+Initialize the `docs/agent-todos/` folder structure for AI agent task tracking. If Obsidian mode is configured via `.claude/agent-todos.local.md`, create the structure in the configured todos directory instead.
 
 ## Workflow
 
@@ -76,5 +76,5 @@ See the skill documentation for details on file format and workflow.
 - This skill only creates the folder structure
 - Use `/todo-creation` to create individual todo files
 - Use `/todo-gh-issue-import` to populate with tasks from GitHub issues
-- Use `/todo-overview` to generate or refresh `docs/agent-todos/TODO_OVERVIEW.md`
+- Use `/todo-overview` to generate or refresh the todo overview
 - Use `/todo-processing` to work with existing todo files

--- a/plugins/agent-todos/skills/todo-migrate-to-obsidian/SKILL.md
+++ b/plugins/agent-todos/skills/todo-migrate-to-obsidian/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: todo-migrate-to-obsidian
+description: This skill should be used when the user asks to "migrate todos to obsidian", "move agent todos to obsidian vault", "use obsidian as primary todo store", "move docs/agent-todos to obsidian", or wants to configure Obsidian as the primary store for this project's todos.
+allowed-tools: Bash, Read, Write, Edit, AskUserQuestion, Skill
+invocation: user
+argument-hint: "[vault-name] [project-name]"
+compatibility: macOS only (requires iCloud Drive with Obsidian vault)
+---
+
+# todo-migrate-to-obsidian
+
+Migrate `docs/agent-todos/` to an Obsidian vault and configure the plugin to write all future todos directly to the vault.
+
+## Workflow
+
+### 1. Gather Input
+
+Collect the vault name and project name. These may come from skill arguments or by asking the user.
+
+- **Vault name** — The Obsidian vault directory name under iCloud Drive's Obsidian folder. List available vaults:
+  ```bash
+  ls ~/Library/Mobile\ Documents/iCloud\~md\~obsidian/Documents/
+  ```
+- **Project name** — Subdirectory name under `agent-todos/` in the vault. Defaults to the current project root directory name (e.g., `my-project`).
+
+If both values are provided as arguments (e.g., `/todo-migrate-to-obsidian vault-of-jens my-project`), parse the first word as vault name and the rest as project name.
+
+If arguments are missing, ask the user using AskUserQuestion.
+
+### 2. Run Migration Script
+
+```bash
+bash <base_directory>/scripts/migrate-to-obsidian.sh "<project_root>" "<vault_name>" "<project_name>"
+```
+
+Where `<base_directory>` is the path shown in "Base directory for this skill:" at the top of the skill invocation, and `<project_root>` is the current project root.
+
+The script:
+
+1. Verifies this is macOS and the vault exists
+2. Creates `<vault>/agent-todos/<project_name>/<category>/` directories
+3. Copies all todo files preserving `DONE_` prefixes and sequential numbering
+4. Prints three config values to stdout in `key=value` format:
+   - `todos_root=<path>`
+   - `vault_root=<path>`
+   - `kanban_file=<path>`
+
+Parse the output lines to extract these three values.
+
+If the script exits with a non-zero status, report the error and stop.
+
+### 3. Write Config File
+
+Create `.claude/agent-todos.local.md` in the project root using the three values from the script output:
+
+```markdown
+---
+todos_root: <todos_root value>
+vault_root: <vault_root value>
+kanban_file: <kanban_file value>
+---
+```
+
+Use the Write tool to create this file at `<project_root>/.claude/agent-todos.local.md`.
+
+### 4. Generate Initial Kanban Board
+
+Run `/todo-overview` to generate the initial Obsidian Kanban board at the configured `kanban_file` path. Confirm the output path from the script's stdout.
+
+### 5. Ask About Source Deletion
+
+Ask the user whether to delete `docs/agent-todos/` from the codebase:
+
+> The todos have been copied to the Obsidian vault at `<todos_root>`. Would you like to delete `docs/agent-todos/` from the codebase?
+
+If the user confirms, delete the directory:
+
+```bash
+rm -rf "<project_root>/docs/agent-todos"
+```
+
+If the user declines, leave the directory in place. Note that all todo skills will now write to the vault path; `docs/agent-todos/` will not receive new files.
+
+## Notes
+
+- macOS only — requires iCloud Drive with an Obsidian vault synced locally
+- Migration copies files — it does not move them; the user decides about source deletion
+- Sequential numbering and `DONE_` prefixes are preserved exactly
+- After migration, all skills (`/todo-creation`, `/todo-overview`, `/todo-moving`) use the vault path automatically via `.claude/agent-todos.local.md`
+- To revert, delete `.claude/agent-todos.local.md` — skills will fall back to `docs/agent-todos/`
+- iCloud Drive may delay local availability of files; ensure the vault is fully synced before migrating

--- a/plugins/agent-todos/skills/todo-migrate-to-obsidian/scripts/migrate-to-obsidian.sh
+++ b/plugins/agent-todos/skills/todo-migrate-to-obsidian/scripts/migrate-to-obsidian.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# migrate-to-obsidian.sh — Copy docs/agent-todos/ to an Obsidian vault and
+# print the resulting config values for .claude/agent-todos.local.md.
+#
+# Usage: migrate-to-obsidian.sh <project_root> <vault_name> [project_name]
+#
+#   project_root  — Root of the project (default: $PWD)
+#   vault_name    — Obsidian vault directory name under iCloud Drive
+#   project_name  — Subdirectory under agent-todos/ in the vault
+#                   (default: basename of project_root)
+#
+# On success, prints to stdout:
+#   todos_root=<full path>
+#   vault_root=<full path>
+#   kanban_file=<full path>
+#
+# Progress/errors are written to stderr.
+
+set -euo pipefail
+
+PROJECT_ROOT="${1:-$PWD}"
+VAULT_NAME="${2:-}"
+PROJECT_NAME="${3:-$(basename "$PROJECT_ROOT")}"
+
+if [ -z "$VAULT_NAME" ]; then
+  echo "Usage: migrate-to-obsidian.sh <project_root> <vault_name> [project_name]" >&2
+  exit 1
+fi
+
+# macOS check
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "Error: This script requires macOS with iCloud Drive." >&2
+  exit 1
+fi
+
+ICLOUD_OBSIDIAN_BASE="$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"
+VAULT_PATH="$ICLOUD_OBSIDIAN_BASE/$VAULT_NAME"
+
+if [ ! -d "$VAULT_PATH" ]; then
+  echo "Error: Vault not found: $VAULT_PATH" >&2
+  echo "Available vaults:" >&2
+  ls "$ICLOUD_OBSIDIAN_BASE" >&2 2>/dev/null || true
+  exit 1
+fi
+
+SOURCE_TODOS="$PROJECT_ROOT/docs/agent-todos"
+
+if [ ! -d "$SOURCE_TODOS" ]; then
+  echo "Error: Source todos directory not found: $SOURCE_TODOS" >&2
+  exit 1
+fi
+
+DEST_TODOS="$VAULT_PATH/agent-todos/$PROJECT_NAME"
+KANBAN_FILE="$VAULT_PATH/agent-todos/$PROJECT_NAME-kanban.md"
+
+copied=0
+
+for category_dir in "$SOURCE_TODOS"/*/; do
+  [ -d "$category_dir" ] || continue
+  category="$(basename "$category_dir")"
+  dest_category="$DEST_TODOS/$category"
+  mkdir -p "$dest_category"
+
+  for src_file in "$category_dir"*.md; do
+    [ -e "$src_file" ] || continue
+    filename="$(basename "$src_file")"
+    dest_file="$dest_category/$filename"
+    cp "$src_file" "$dest_file"
+    copied=$((copied + 1))
+    echo "copied: $category/$filename" >&2
+  done
+done
+
+echo "done: copied $copied file(s) to $DEST_TODOS" >&2
+
+# Print config values to stdout (full paths, no tilde)
+echo "todos_root=$DEST_TODOS"
+echo "vault_root=$VAULT_PATH"
+echo "kanban_file=$KANBAN_FILE"

--- a/plugins/agent-todos/skills/todo-moving/SKILL.md
+++ b/plugins/agent-todos/skills/todo-moving/SKILL.md
@@ -13,13 +13,13 @@ Move selected open todo files from one category folder to another and renumber o
 
 ## Purpose
 
-Apply this skill to todo migrations inside `docs/agent-todos/` when number consistency is required.
+Apply this skill to todo migrations inside the configured todos directory (default: `docs/agent-todos/`) when number consistency is required.
 
 ## Arguments
 
-- `source-category`: folder under `docs/agent-todos/` that currently contains the todos, for example `misc`
+- `source-category`: folder under the todos directory that currently contains the todos, for example `misc`
 - `todo-set`: comma-separated list of numbers and/or ranges, for example `0011-0014,0020`
-- `target-category`: destination folder under `docs/agent-todos/`, for example `seo`
+- `target-category`: destination folder under the todos directory, for example `seo`
 
 ## Workflow
 
@@ -36,7 +36,7 @@ Where:
 - `<project_root>` is the repository root.
 
 3. Review script output for moved files, warnings, and renumbering actions.
-4. Run `/todo-overview` to refresh `docs/agent-todos/TODO_OVERVIEW.md`.
+4. Run `/todo-overview` to refresh the todo overview.
 
 ## Todo Set Format
 

--- a/plugins/agent-todos/skills/todo-moving/scripts/move-todos.sh
+++ b/plugins/agent-todos/skills/todo-moving/scripts/move-todos.sh
@@ -12,7 +12,34 @@ if [ -z "$SOURCE_CATEGORY" ] || [ -z "$TARGET_CATEGORY" ] || [ -z "$TODO_SET" ];
   exit 1
 fi
 
-TODOS_ROOT="$PROJECT_ROOT/docs/agent-todos"
+# ---------------------------------------------------------------------------
+# Agent-todos config reader
+# Reads .claude/agent-todos.local.md and sets TODOS_ROOT, VAULT_ROOT, KANBAN_FILE
+# ---------------------------------------------------------------------------
+_read_fm_key() {
+  awk -v k="$1" '
+    NR==1&&/^---$/{f=1;next}
+    f&&/^---$/{exit}
+    f&&$1==k":"{sub("^"k":[[:space:]]*","");gsub(/^"|"$/,"");gsub(/^\047|\047$/,"");print;exit}
+  ' "$2"
+}
+
+read_agent_todos_config() {
+  local config_file="$PROJECT_ROOT/.claude/agent-todos.local.md"
+  TODOS_ROOT="$PROJECT_ROOT/docs/agent-todos"
+  VAULT_ROOT=""
+  KANBAN_FILE=""
+  [ -f "$config_file" ] || return 0
+  local v
+  v="$(_read_fm_key todos_root "$config_file")";  [ -n "$v" ] && TODOS_ROOT="${v/#\~/$HOME}"
+  v="$(_read_fm_key vault_root "$config_file")";  [ -n "$v" ] && VAULT_ROOT="${v/#\~/$HOME}"
+  v="$(_read_fm_key kanban_file "$config_file")"; [ -n "$v" ] && KANBAN_FILE="${v/#\~/$HOME}"
+  if [ -z "$KANBAN_FILE" ] && [ "$TODOS_ROOT" != "$PROJECT_ROOT/docs/agent-todos" ]; then
+    KANBAN_FILE="$(dirname "$TODOS_ROOT")/$(basename "$TODOS_ROOT")-kanban.md"
+  fi
+}
+
+read_agent_todos_config
 SOURCE_DIR="$TODOS_ROOT/$SOURCE_CATEGORY"
 TARGET_DIR="$TODOS_ROOT/$TARGET_CATEGORY"
 

--- a/plugins/agent-todos/skills/todo-obsidian-icloud-import/SKILL.md
+++ b/plugins/agent-todos/skills/todo-obsidian-icloud-import/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Import agent todos from a local Obsidian vault synced via iCloud Drive. Use when
   the user asks to "import from obsidian", "import obsidian todos", "sync obsidian
   todos", "get todos from obsidian", or wants to pull todos from an Obsidian vault
-  into docs/agent-todos/.
+  into the configured todos directory (default: docs/agent-todos/).
 compatibility: macOS only (requires iCloud Drive with Obsidian vault)
 allowed-tools: Bash, Read, Write, Edit, Skill, AskUserQuestion
 invocation: user
@@ -13,7 +13,7 @@ argument-hint: "[vaultname] [source-category]"
 
 # todo-obsidian-icloud-import
 
-Import agent todo markdown files from a local Obsidian vault stored on iCloud Drive into the project's `docs/agent-todos/` workflow.
+Import agent todo markdown files from a local Obsidian vault stored on iCloud Drive into the project's configured todos directory (default: `docs/agent-todos/`).
 
 ## Prerequisites
 
@@ -74,9 +74,9 @@ If no files are found, inform the user and stop.
 
 ### 4. Choose Destination Category
 
-The source category in the Obsidian vault may not match the desired local category. Ask the user which local `docs/agent-todos/` category the imported todos should be placed in.
+The source category in the Obsidian vault may not match the desired local category. Ask the user which category the imported todos should be placed in.
 
-List existing local categories by scanning subdirectories of `docs/agent-todos/` in the project root. Present them as options via AskUserQuestion, allowing the user to pick an existing category or type a new one.
+List existing categories by scanning subdirectories of the configured todos directory in the project root. Present them as options via AskUserQuestion, allowing the user to pick an existing category or type a new one.
 
 ### 5. Import Each Todo
 
@@ -117,7 +117,7 @@ Importing from vault "WorkNotes" source category "my-project":
 1. Script finds `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/WorkNotes/agent-todos/my-project/0001_fix_layout.md`
 2. User is asked to choose a destination category from existing local folders (e.g., `misc`, `data`) or type a new one
 3. User picks `misc` as the destination
-4. `/todo-creation misc "Fix layout"` creates `docs/agent-todos/misc/0005_fix_layout.md`
+4. `/todo-creation misc "Fix layout"` creates `<todos-directory>/misc/0005_fix_layout.md`
 5. Content is copied from the Obsidian file to the local todo
 6. Status is updated to `ready`
 7. User confirms deletion; source file is moved to Trash
@@ -129,5 +129,5 @@ Importing from vault "WorkNotes" source category "my-project":
 - Source files are moved to Trash (not permanently deleted) for safety
 - If the Obsidian vault path does not exist, the script will report an error
 - iCloud Drive may sync files with delay; ensure files are downloaded locally before importing
-- The vault's `agent-todos/` directory structure mirrors the local `docs/agent-todos/` convention
-- Keep `docs/agent-todos/TODO_OVERVIEW.md` in sync by invoking `/todo-overview` after imports
+- The vault's `agent-todos/` directory structure mirrors the local todos directory convention
+- Keep the todo overview in sync by invoking `/todo-overview` after imports

--- a/plugins/agent-todos/skills/todo-overview/SKILL.md
+++ b/plugins/agent-todos/skills/todo-overview/SKILL.md
@@ -1,31 +1,34 @@
 ---
 name: todo-overview
-description: This skill should be used when the user asks to "create todo overview", "update todo overview", "generate TODO_OVERVIEW.md", "list all todos by status", "show todo table", or wants a markdown table overview for docs/agent-todos.
+description: This skill should be used when the user asks to "create todo overview", "update todo overview", "generate TODO_OVERVIEW.md", "list all todos by status", "show todo table", "update kanban board", or wants a markdown table or Obsidian Kanban overview for the configured todos directory (default: docs/agent-todos).
 allowed-tools: Bash, Read, Write, Edit
 invocation: user
 ---
 
 # todo-overview
 
-Create or update `docs/agent-todos/TODO_OVERVIEW.md` with a Mermaid Kanban followed by a markdown table of all todo files.
+Generate or update the todo overview from the configured todos directory (default: `docs/agent-todos/`).
+
+**Default mode** — generates `TODO_OVERVIEW.md` with a Mermaid Kanban and a markdown table.
+
+**Obsidian mode** (when `.claude/agent-todos.local.md` sets `kanban_file`) — generates an Obsidian Kanban board file at the `kanban_file` path instead.
 
 ## Output Format
 
-Write sections in this order:
+### Default mode
 
-1. `## Todo Kanban` with lanes `new`, `ready`, `doing`, and `done`
-2. `## Todo List` table with exactly these columns:
+Writes sections in this order:
 
-- `category`
-- `todo`
-- `status`
+1. `## Todo Kanban` with lanes `new`, `ready`, `doing`, and `done` (Mermaid)
+2. `## Todo List` table with columns `category`, `todo`, `status`
 
-Each row should represent one todo file from category subdirectories under `docs/agent-todos/`.
+### Obsidian mode
+
+Generates an Obsidian Kanban plugin board file with columns New, Ready, Doing, Done. DONE_ files appear as `- [x]` checked cards in the Done column.
 
 ## Workflow
 
-1. Verify `docs/agent-todos/` exists.
-2. Run the bundled script:
+1. Run the bundled script:
 
 ```bash
 bash <base_directory>/scripts/update-overview.sh "<project_root>"
@@ -36,13 +39,13 @@ Where:
 - `<base_directory>` is the path shown in "Base directory for this skill:" at invocation time.
 - `<project_root>` is the current project root.
 
-3. Confirm the generated file path from script output.
-4. Optionally read `docs/agent-todos/TODO_OVERVIEW.md` to verify Kanban + table output and status values.
+2. Confirm the generated file path from script output.
+3. Optionally read the output file to verify Kanban and status values.
 
 ## Notes
 
+- Reads `.claude/agent-todos.local.md` to determine todos directory and output format.
 - Include both open and completed todos.
-- Exclude `docs/agent-todos/README.md` and `docs/agent-todos/TODO_OVERVIEW.md` from the row scan.
 - Preserve status values from YAML frontmatter when present.
 - Infer `status: done` for `DONE_` files that lack frontmatter.
-- Generate todo links with a leading slash (`/docs/...`) so links resolve correctly on GitHub.
+- In default mode, generate todo links with a leading slash (`/docs/...`) so links resolve correctly on GitHub.

--- a/plugins/agent-todos/skills/todo-overview/scripts/update-overview.sh
+++ b/plugins/agent-todos/skills/todo-overview/scripts/update-overview.sh
@@ -2,8 +2,42 @@
 set -euo pipefail
 
 PROJECT_ROOT="${1:-$PWD}"
-TODOS_DIR="$PROJECT_ROOT/docs/agent-todos"
-OUTPUT_FILE="$TODOS_DIR/TODO_OVERVIEW.md"
+
+# ---------------------------------------------------------------------------
+# Agent-todos config reader
+# Reads .claude/agent-todos.local.md and sets TODOS_ROOT, VAULT_ROOT, KANBAN_FILE
+# ---------------------------------------------------------------------------
+_read_fm_key() {
+  awk -v k="$1" '
+    NR==1&&/^---$/{f=1;next}
+    f&&/^---$/{exit}
+    f&&$1==k":"{sub("^"k":[[:space:]]*","");gsub(/^"|"$/,"");gsub(/^\047|\047$/,"");print;exit}
+  ' "$2"
+}
+
+read_agent_todos_config() {
+  local config_file="$PROJECT_ROOT/.claude/agent-todos.local.md"
+  TODOS_ROOT="$PROJECT_ROOT/docs/agent-todos"
+  VAULT_ROOT=""
+  KANBAN_FILE=""
+  [ -f "$config_file" ] || return 0
+  local v
+  v="$(_read_fm_key todos_root "$config_file")";  [ -n "$v" ] && TODOS_ROOT="${v/#\~/$HOME}"
+  v="$(_read_fm_key vault_root "$config_file")";  [ -n "$v" ] && VAULT_ROOT="${v/#\~/$HOME}"
+  v="$(_read_fm_key kanban_file "$config_file")"; [ -n "$v" ] && KANBAN_FILE="${v/#\~/$HOME}"
+  if [ -z "$KANBAN_FILE" ] && [ "$TODOS_ROOT" != "$PROJECT_ROOT/docs/agent-todos" ]; then
+    KANBAN_FILE="$(dirname "$TODOS_ROOT")/$(basename "$TODOS_ROOT")-kanban.md"
+  fi
+}
+
+read_agent_todos_config
+TODOS_DIR="$TODOS_ROOT"
+
+if [ -n "$KANBAN_FILE" ]; then
+  OUTPUT_FILE="$KANBAN_FILE"
+else
+  OUTPUT_FILE="$TODOS_DIR/TODO_OVERVIEW.md"
+fi
 
 if [ ! -d "$TODOS_DIR" ]; then
   echo "Error: $TODOS_DIR does not exist" >&2
@@ -64,16 +98,62 @@ while IFS= read -r file; do
     ticket=""
   fi
 
-  printf '%s\t%s\t%s\t%s\t%s\n' "$category" "$title" "$status" "$rel_path" "$ticket" >> "$rowsfile"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$category" "$title" "$status" "$rel_path" "$ticket" "$file" >> "$rowsfile"
 done < <(find "$TODOS_DIR" -mindepth 2 -maxdepth 2 -type f -name '*.md' ! -name 'README.md' ! -name 'overview.md' ! -name 'TODO_OVERVIEW.md' | sort)
 
+# ---------------------------------------------------------------------------
+# Obsidian Kanban generation
+# ---------------------------------------------------------------------------
+obsidian_lane() {
+  local lane_status="$1"
+  local lane_label="$2"
+  local checkbox="$3"
+  printf '## %s\n' "$lane_label"
+  while IFS=$'\t' read -r category title status rel_path ticket full_path; do
+    if [ "$status" = "$lane_status" ]; then
+      local wiki_path esc_title
+      if [ -n "$VAULT_ROOT" ]; then
+        wiki_path="${full_path#"$VAULT_ROOT/"}"
+      else
+        wiki_path="${rel_path#/}"
+      fi
+      wiki_path="${wiki_path%.md}"
+      esc_title="${title//|/\\|}"
+      printf '%s [[%s|%s]]\n' "$checkbox" "$wiki_path" "$esc_title"
+    fi
+  done < "$rowsfile"
+  printf '\n'
+}
+
+generate_obsidian_kanban() {
+  printf -- '---\nkanban-plugin: board\n---\n\n'
+  obsidian_lane "new"   "New"   "- [ ]"
+  obsidian_lane "ready" "Ready" "- [ ]"
+  obsidian_lane "doing" "Doing" "- [ ]"
+  obsidian_lane "done"  "Done"  "- [x]"
+  cat <<'KANBAN_EOF'
+***
+
+## Archive
+
+%% kanban:settings
+```json
+{"kanban-plugin":"board"}
+```
+%%
+KANBAN_EOF
+}
+
+# ---------------------------------------------------------------------------
+# Mermaid Kanban generation (default)
+# ---------------------------------------------------------------------------
 append_lane() {
   local lane="$1"
   local lane_label="$2"
   local has_lane_rows=0
 
   printf '  %s[%s]\n' "$lane" "$lane_label" >> "$kanbanfile"
-  while IFS=$'\t' read -r category title status rel_path ticket; do
+  while IFS=$'\t' read -r category title status rel_path ticket full_path; do
     if [ "$status" = "$lane" ] && [ -n "$ticket" ]; then
       has_lane_rows=1
       esc_title="${title//]/\\]}"
@@ -86,55 +166,64 @@ append_lane() {
   fi
 }
 
-{
-  echo "# Todo Overview"
-  echo
-  echo "Generated on $(date '+%F %H:%M:%S %Z')."
+has_rows=0
+while IFS=$'\t' read -r _ _ _ _ _ _; do
+  has_rows=1
+  break
+done < "$rowsfile"
 
-  has_rows=0
-  while IFS=$'\t' read -r _ _ _ _ _; do
-    has_rows=1
-    break
-  done < "$rowsfile"
+if [ -n "$KANBAN_FILE" ]; then
+  # Obsidian Kanban format
+  generate_obsidian_kanban > "$tmpfile"
+else
+  # Mermaid format
+  {
+    echo "# Todo Overview"
+    echo
+    echo "Generated on $(date '+%F %H:%M:%S %Z')."
 
-  echo
-  echo "## Todo Kanban"
-  echo
+    echo
+    echo "## Todo Kanban"
+    echo
 
-  if [ "$has_rows" -eq 0 ]; then
-    echo "_No todos available for visualization._"
-  else
-    : > "$kanbanfile"
-    echo '```mermaid' >> "$kanbanfile"
-    echo "%%{init: {\"theme\":\"neutral\"}}%%" >> "$kanbanfile"
-    echo "kanban" >> "$kanbanfile"
-    append_lane "new" "New"
-    append_lane "ready" "Ready"
-    append_lane "doing" "Doing"
-    append_lane "done" "Done"
-    echo '```' >> "$kanbanfile"
+    if [ "$has_rows" -eq 0 ]; then
+      echo "_No todos available for visualization._"
+    else
+      : > "$kanbanfile"
+      echo '```mermaid' >> "$kanbanfile"
+      echo "%%{init: {\"theme\":\"neutral\"}}%%" >> "$kanbanfile"
+      echo "kanban" >> "$kanbanfile"
+      append_lane "new" "New"
+      append_lane "ready" "Ready"
+      append_lane "doing" "Doing"
+      append_lane "done" "Done"
+      echo '```' >> "$kanbanfile"
 
-    cat "$kanbanfile"
-  fi
+      cat "$kanbanfile"
+    fi
 
-  echo
-  echo "## Todo List"
-  echo
-  echo "| category | todo | status |"
-  echo "| --- | --- | --- |"
+    echo
+    echo "## Todo List"
+    echo
+    echo "| category | todo | status |"
+    echo "| --- | --- | --- |"
 
-  if [ "$has_rows" -eq 0 ]; then
-    echo "| - | - | - |"
-  else
-    while IFS=$'\t' read -r category title status rel_path ticket; do
-      esc_title="${title//|/\\|}"
-      esc_category="${category//|/\\|}"
-      esc_status="${status//|/\\|}"
+    if [ "$has_rows" -eq 0 ]; then
+      echo "| - | - | - |"
+    else
+      while IFS=$'\t' read -r category title status rel_path ticket full_path; do
+        esc_title="${title//|/\\|}"
+        esc_category="${category//|/\\|}"
+        esc_status="${status//|/\\|}"
 
-      echo "| $esc_category | [$esc_title]($rel_path) | $esc_status |"
-    done < "$rowsfile"
-  fi
-} > "$tmpfile"
+        echo "| $esc_category | [$esc_title]($rel_path) | $esc_status |"
+      done < "$rowsfile"
+    fi
+  } > "$tmpfile"
+fi
+
+# Ensure parent directory exists (KANBAN_FILE may be outside project root)
+mkdir -p "$(dirname "$OUTPUT_FILE")"
 
 mv "$tmpfile" "$OUTPUT_FILE"
 echo "$OUTPUT_FILE"

--- a/plugins/agent-todos/skills/todo-processing/SKILL.md
+++ b/plugins/agent-todos/skills/todo-processing/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: todo-processing
-description: Work with AI agent todo files in docs/agent-todos
+description: Work with AI agent todo files in the configured todos directory (default: docs/agent-todos)
 invocation: none
 ---
 
 # todo-processing
 
-This skill describes how to work with todo files located in `docs/agent-todos/`. These files track tasks for AI agents working on this project.
+This skill describes how to work with todo files located in the configured todos directory (default: `docs/agent-todos/`). These files track tasks for AI agents working on this project.
 
 ## Directory Structure
 
 Todo files are organized in category subdirectories. Categories are flexible and can be created as needed.
 
+The todos directory is configurable via `.claude/agent-todos.local.md` (default: `docs/agent-todos/`).
+
 ```
-docs/agent-todos/
+<todos-directory>/
 ├── [category]/     # e.g., data, menu, misc, tags, thai-food-dict
 │   ├── 0001_task-description.md
 │   ├── DONE_0002_completed-task.md
@@ -110,7 +112,7 @@ When assigned a task:
 2. Update the frontmatter status from `ready` → `doing`
 3. Note any prerequisites or context
 4. Check for existing progress entries
-5. Run `/todo-overview` after status changes to refresh `docs/agent-todos/TODO_OVERVIEW.md`
+5. Run `/todo-overview` after status changes to refresh the todo overview
 
 ### 2. Working on a Task
 
@@ -149,7 +151,7 @@ When task is complete:
 2. Add a final progress entry documenting completion
 3. If the file has checkboxes, mark them all as `[x]`
 4. Rename the file with `DONE_` prefix
-5. Run `/todo-overview` after marking done to refresh `docs/agent-todos/TODO_OVERVIEW.md`
+5. Run `/todo-overview` after marking done to refresh the todo overview
 
 ## Best Practices
 
@@ -159,9 +161,11 @@ When task is complete:
 4. **Link to related files** - Reference files that were created/modified
 5. **Ask before assuming** - Add questions to the file and ask the user
 6. **Update internal docs** - After completing a task, update relevant documentation
-7. **Keep overview current** - Trigger `/todo-overview` whenever todo status changes
+7. **Keep overview current** — Trigger `/todo-overview` whenever todo status changes
 
 ## Finding Tasks
+
+Replace `docs/agent-todos` with your configured todos directory if using Obsidian mode (see `.claude/agent-todos.local.md`).
 
 To list all open (not done) tasks:
 


### PR DESCRIPTION
## Summary

- **New config pattern**: `.claude/agent-todos.local.md` with `todos_root`, `vault_root`, and `kanban_file` fields redirects all todo operations to an Obsidian vault; falls back to `docs/agent-todos/` when absent
- **Scripts parameterized**: `create-todo.sh`, `move-todos.sh`, and `update-overview.sh` each gain an inline `read_agent_todos_config()` function — no shared script, fully self-contained
- **Obsidian Kanban output**: `update-overview.sh` generates an Obsidian Kanban plugin board file (wiki links, New/Ready/Doing/Done columns) when `kanban_file` is configured; default Mermaid output is unchanged
- **New skill** `/todo-migrate-to-obsidian`: one-step migration from `docs/agent-todos/` to a vault — copies files, writes config, generates initial Kanban board
- **Docs**: all 7 SKILL.md files updated; `docs/plugins/agent-todos.md` gains a Configuration section and Kanban format reference
- **Version**: `0.2.5` → `0.3.0`

## Test plan

- [ ] Without `.claude/agent-todos.local.md`: `create-todo.sh`, `move-todos.sh`, `update-overview.sh` behave identically to v0.2.5
- [ ] With config pointing to an Obsidian path: `create-todo.sh` creates files in the vault directory
- [ ] `update-overview.sh` with Obsidian config generates a valid Obsidian Kanban `.md` file at `kanban_file`
- [ ] DONE_ files appear as `- [x]` cards in the Done column (not archived)
- [ ] Wiki links are relative to `vault_root` with `.md` stripped
- [ ] `/todo-migrate-to-obsidian` skill: copies files, writes config, calls `/todo-overview`
- [ ] `migrate-to-obsidian.sh` exits non-zero on non-macOS or missing vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)