### PR TITLE
refactor(agent-todos): JSON config with camelCase keys (v0.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "agent-todos",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "source": "./plugins/agent-todos",
       "description": "Agent todo file management skills"
     },

--- a/docs/plugins/agent-todos.md
+++ b/docs/plugins/agent-todos.md
@@ -1,6 +1,6 @@
 # agent-todos
 
-`agent-todos` provides structured todo workflows for AI agents. By default, todos are stored under `docs/agent-todos/` inside the project. For workplaces where committing AI task files is not acceptable, todos can be stored in an Obsidian vault instead — configured per project via `.claude/agent-todos.local.md`.
+`agent-todos` provides structured todo workflows for AI agents. By default, todos are stored under `docs/agent-todos/` inside the project. For workplaces where committing AI task files is not acceptable, todos can be stored in an Obsidian vault instead — configured per project via `.claude/agent-todos.local.json`.
 
 ## What It Does
 
@@ -32,21 +32,21 @@ All skills read from and write to `docs/agent-todos/` inside the project root. N
 
 ### Obsidian mode
 
-Create `.claude/agent-todos.local.md` in the project root (this file is gitignored by Claude Code conventions):
+Create `.claude/agent-todos.local.json` in the project root (this file is gitignored by Claude Code conventions):
 
-```markdown
----
-todos_root: ~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault-name>/agent-todos/<project-name>
-vault_root: ~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault-name>
-kanban_file: ~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault-name>/agent-todos/<project-name>-kanban.md
----
+```json
+{
+  "todosRoot": "~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault-name>/agent-todos/<project-name>",
+  "vaultRoot": "~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault-name>",
+  "kanbanFile": "~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault-name>/agent-todos/<project-name>-kanban.md"
+}
 ```
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `todos_root` | yes | Absolute path to the todos root (holds category subdirectories). Replaces `docs/agent-todos/`. |
-| `vault_root` | no | Obsidian vault root. Used to compute wiki-link paths in the Kanban board. |
-| `kanban_file` | no | Obsidian Kanban output path. Defaults to `$(dirname todos_root)/$(basename todos_root)-kanban.md`. |
+| `todosRoot` | yes | Absolute path to the todos root (holds category subdirectories). Replaces `docs/agent-todos/`. |
+| `vaultRoot` | no | Obsidian vault root. Used to compute wiki-link paths in the Kanban board. |
+| `kanbanFile` | no | Obsidian Kanban output path. Defaults to `$(dirname todosRoot)/$(basename todosRoot)-kanban.md`. |
 
 `~` in paths is expanded to `$HOME` at runtime.
 
@@ -54,7 +54,7 @@ When `kanban_file` is set (or derived from a non-default `todos_root`), `/todo-o
 
 ### Switching back to default
 
-Delete `.claude/agent-todos.local.md`. All skills fall back to `docs/agent-todos/` immediately — no other changes needed.
+Delete `.claude/agent-todos.local.json`. All skills fall back to `docs/agent-todos/` immediately — no other changes needed.
 
 ### Migrating existing todos to Obsidian
 

--- a/plugins/agent-todos/.claude-plugin/plugin.json
+++ b/plugins/agent-todos/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-todos",
   "description": "Agent todo file management skills",
-  "version": "0.3.0"
+  "version": "0.4.0"
 }

--- a/plugins/agent-todos/skills/todo-creation/scripts/create-todo.sh
+++ b/plugins/agent-todos/skills/todo-creation/scripts/create-todo.sh
@@ -27,26 +27,31 @@ PROJECT_ROOT="$BASE_DIR"
 
 # ---------------------------------------------------------------------------
 # Agent-todos config reader
-# Reads .claude/agent-todos.local.md and sets TODOS_ROOT, VAULT_ROOT, KANBAN_FILE
+# Reads .claude/agent-todos.local.json and sets TODOS_ROOT, VAULT_ROOT, KANBAN_FILE
 # ---------------------------------------------------------------------------
-_read_fm_key() {
-  awk -v k="$1" '
-    NR==1&&/^---$/{f=1;next}
-    f&&/^---$/{exit}
-    f&&$1==k":"{sub("^"k":[[:space:]]*","");gsub(/^"|"$/,"");gsub(/^\047|\047$/,"");print;exit}
-  ' "$2"
+_read_json_key() {
+  python3 - "$1" "$2" <<'PYEOF' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    v = d.get(sys.argv[2])
+    if v is not None:
+        print(v)
+except Exception:
+    pass
+PYEOF
 }
 
 read_agent_todos_config() {
-  local config_file="$PROJECT_ROOT/.claude/agent-todos.local.md"
+  local config_file="$PROJECT_ROOT/.claude/agent-todos.local.json"
   TODOS_ROOT="$PROJECT_ROOT/docs/agent-todos"
   VAULT_ROOT=""
   KANBAN_FILE=""
   [ -f "$config_file" ] || return 0
   local v
-  v="$(_read_fm_key todos_root "$config_file")";  [ -n "$v" ] && TODOS_ROOT="${v/#\~/$HOME}"
-  v="$(_read_fm_key vault_root "$config_file")";  [ -n "$v" ] && VAULT_ROOT="${v/#\~/$HOME}"
-  v="$(_read_fm_key kanban_file "$config_file")"; [ -n "$v" ] && KANBAN_FILE="${v/#\~/$HOME}"
+  v="$(_read_json_key "$config_file" todosRoot)";  [ -n "$v" ] && TODOS_ROOT="${v/#\~/$HOME}"
+  v="$(_read_json_key "$config_file" vaultRoot)";  [ -n "$v" ] && VAULT_ROOT="${v/#\~/$HOME}"
+  v="$(_read_json_key "$config_file" kanbanFile)"; [ -n "$v" ] && KANBAN_FILE="${v/#\~/$HOME}"
   if [ -z "$KANBAN_FILE" ] && [ "$TODOS_ROOT" != "$PROJECT_ROOT/docs/agent-todos" ]; then
     KANBAN_FILE="$(dirname "$TODOS_ROOT")/$(basename "$TODOS_ROOT")-kanban.md"
   fi

--- a/plugins/agent-todos/skills/todo-init/SKILL.md
+++ b/plugins/agent-todos/skills/todo-init/SKILL.md
@@ -7,7 +7,7 @@ invocation: user
 
 # todo-init
 
-Initialize the `docs/agent-todos/` folder structure for AI agent task tracking. If Obsidian mode is configured via `.claude/agent-todos.local.md`, create the structure in the configured todos directory instead.
+Initialize the `docs/agent-todos/` folder structure for AI agent task tracking. If Obsidian mode is configured via `.claude/agent-todos.local.json`, create the structure in the configured todos directory instead.
 
 ## Workflow
 

--- a/plugins/agent-todos/skills/todo-migrate-to-obsidian/SKILL.md
+++ b/plugins/agent-todos/skills/todo-migrate-to-obsidian/SKILL.md
@@ -51,17 +51,17 @@ If the script exits with a non-zero status, report the error and stop.
 
 ### 3. Write Config File
 
-Create `.claude/agent-todos.local.md` in the project root using the three values from the script output:
+Create `.claude/agent-todos.local.json` in the project root using the three values from the script output:
 
-```markdown
----
-todos_root: <todos_root value>
-vault_root: <vault_root value>
-kanban_file: <kanban_file value>
----
+```json
+{
+  "todosRoot": "<todos_root value>",
+  "vaultRoot": "<vault_root value>",
+  "kanbanFile": "<kanban_file value>"
+}
 ```
 
-Use the Write tool to create this file at `<project_root>/.claude/agent-todos.local.md`.
+Use the Write tool to create this file at `<project_root>/.claude/agent-todos.local.json`.
 
 ### 4. Generate Initial Kanban Board
 
@@ -86,6 +86,6 @@ If the user declines, leave the directory in place. Note that all todo skills wi
 - macOS only — requires iCloud Drive with an Obsidian vault synced locally
 - Migration copies files — it does not move them; the user decides about source deletion
 - Sequential numbering and `DONE_` prefixes are preserved exactly
-- After migration, all skills (`/todo-creation`, `/todo-overview`, `/todo-moving`) use the vault path automatically via `.claude/agent-todos.local.md`
-- To revert, delete `.claude/agent-todos.local.md` — skills will fall back to `docs/agent-todos/`
+- After migration, all skills (`/todo-creation`, `/todo-overview`, `/todo-moving`) use the vault path automatically via `.claude/agent-todos.local.json`
+- To revert, delete `.claude/agent-todos.local.json` — skills will fall back to `docs/agent-todos/`
 - iCloud Drive may delay local availability of files; ensure the vault is fully synced before migrating

--- a/plugins/agent-todos/skills/todo-moving/scripts/move-todos.sh
+++ b/plugins/agent-todos/skills/todo-moving/scripts/move-todos.sh
@@ -14,26 +14,31 @@ fi
 
 # ---------------------------------------------------------------------------
 # Agent-todos config reader
-# Reads .claude/agent-todos.local.md and sets TODOS_ROOT, VAULT_ROOT, KANBAN_FILE
+# Reads .claude/agent-todos.local.json and sets TODOS_ROOT, VAULT_ROOT, KANBAN_FILE
 # ---------------------------------------------------------------------------
-_read_fm_key() {
-  awk -v k="$1" '
-    NR==1&&/^---$/{f=1;next}
-    f&&/^---$/{exit}
-    f&&$1==k":"{sub("^"k":[[:space:]]*","");gsub(/^"|"$/,"");gsub(/^\047|\047$/,"");print;exit}
-  ' "$2"
+_read_json_key() {
+  python3 - "$1" "$2" <<'PYEOF' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    v = d.get(sys.argv[2])
+    if v is not None:
+        print(v)
+except Exception:
+    pass
+PYEOF
 }
 
 read_agent_todos_config() {
-  local config_file="$PROJECT_ROOT/.claude/agent-todos.local.md"
+  local config_file="$PROJECT_ROOT/.claude/agent-todos.local.json"
   TODOS_ROOT="$PROJECT_ROOT/docs/agent-todos"
   VAULT_ROOT=""
   KANBAN_FILE=""
   [ -f "$config_file" ] || return 0
   local v
-  v="$(_read_fm_key todos_root "$config_file")";  [ -n "$v" ] && TODOS_ROOT="${v/#\~/$HOME}"
-  v="$(_read_fm_key vault_root "$config_file")";  [ -n "$v" ] && VAULT_ROOT="${v/#\~/$HOME}"
-  v="$(_read_fm_key kanban_file "$config_file")"; [ -n "$v" ] && KANBAN_FILE="${v/#\~/$HOME}"
+  v="$(_read_json_key "$config_file" todosRoot)";  [ -n "$v" ] && TODOS_ROOT="${v/#\~/$HOME}"
+  v="$(_read_json_key "$config_file" vaultRoot)";  [ -n "$v" ] && VAULT_ROOT="${v/#\~/$HOME}"
+  v="$(_read_json_key "$config_file" kanbanFile)"; [ -n "$v" ] && KANBAN_FILE="${v/#\~/$HOME}"
   if [ -z "$KANBAN_FILE" ] && [ "$TODOS_ROOT" != "$PROJECT_ROOT/docs/agent-todos" ]; then
     KANBAN_FILE="$(dirname "$TODOS_ROOT")/$(basename "$TODOS_ROOT")-kanban.md"
   fi

--- a/plugins/agent-todos/skills/todo-overview/SKILL.md
+++ b/plugins/agent-todos/skills/todo-overview/SKILL.md
@@ -11,7 +11,7 @@ Generate or update the todo overview from the configured todos directory (defaul
 
 **Default mode** — generates `TODO_OVERVIEW.md` with a Mermaid Kanban and a markdown table.
 
-**Obsidian mode** (when `.claude/agent-todos.local.md` sets `kanban_file`) — generates an Obsidian Kanban board file at the `kanban_file` path instead.
+**Obsidian mode** (when `.claude/agent-todos.local.json` sets `kanban_file`) — generates an Obsidian Kanban board file at the `kanban_file` path instead.
 
 ## Output Format
 
@@ -44,7 +44,7 @@ Where:
 
 ## Notes
 
-- Reads `.claude/agent-todos.local.md` to determine todos directory and output format.
+- Reads `.claude/agent-todos.local.json` to determine todos directory and output format.
 - Include both open and completed todos.
 - Preserve status values from YAML frontmatter when present.
 - Infer `status: done` for `DONE_` files that lack frontmatter.

--- a/plugins/agent-todos/skills/todo-overview/scripts/update-overview.sh
+++ b/plugins/agent-todos/skills/todo-overview/scripts/update-overview.sh
@@ -5,26 +5,31 @@ PROJECT_ROOT="${1:-$PWD}"
 
 # ---------------------------------------------------------------------------
 # Agent-todos config reader
-# Reads .claude/agent-todos.local.md and sets TODOS_ROOT, VAULT_ROOT, KANBAN_FILE
+# Reads .claude/agent-todos.local.json and sets TODOS_ROOT, VAULT_ROOT, KANBAN_FILE
 # ---------------------------------------------------------------------------
-_read_fm_key() {
-  awk -v k="$1" '
-    NR==1&&/^---$/{f=1;next}
-    f&&/^---$/{exit}
-    f&&$1==k":"{sub("^"k":[[:space:]]*","");gsub(/^"|"$/,"");gsub(/^\047|\047$/,"");print;exit}
-  ' "$2"
+_read_json_key() {
+  python3 - "$1" "$2" <<'PYEOF' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    v = d.get(sys.argv[2])
+    if v is not None:
+        print(v)
+except Exception:
+    pass
+PYEOF
 }
 
 read_agent_todos_config() {
-  local config_file="$PROJECT_ROOT/.claude/agent-todos.local.md"
+  local config_file="$PROJECT_ROOT/.claude/agent-todos.local.json"
   TODOS_ROOT="$PROJECT_ROOT/docs/agent-todos"
   VAULT_ROOT=""
   KANBAN_FILE=""
   [ -f "$config_file" ] || return 0
   local v
-  v="$(_read_fm_key todos_root "$config_file")";  [ -n "$v" ] && TODOS_ROOT="${v/#\~/$HOME}"
-  v="$(_read_fm_key vault_root "$config_file")";  [ -n "$v" ] && VAULT_ROOT="${v/#\~/$HOME}"
-  v="$(_read_fm_key kanban_file "$config_file")"; [ -n "$v" ] && KANBAN_FILE="${v/#\~/$HOME}"
+  v="$(_read_json_key "$config_file" todosRoot)";  [ -n "$v" ] && TODOS_ROOT="${v/#\~/$HOME}"
+  v="$(_read_json_key "$config_file" vaultRoot)";  [ -n "$v" ] && VAULT_ROOT="${v/#\~/$HOME}"
+  v="$(_read_json_key "$config_file" kanbanFile)"; [ -n "$v" ] && KANBAN_FILE="${v/#\~/$HOME}"
   if [ -z "$KANBAN_FILE" ] && [ "$TODOS_ROOT" != "$PROJECT_ROOT/docs/agent-todos" ]; then
     KANBAN_FILE="$(dirname "$TODOS_ROOT")/$(basename "$TODOS_ROOT")-kanban.md"
   fi

--- a/plugins/agent-todos/skills/todo-processing/SKILL.md
+++ b/plugins/agent-todos/skills/todo-processing/SKILL.md
@@ -12,7 +12,7 @@ This skill describes how to work with todo files located in the configured todos
 
 Todo files are organized in category subdirectories. Categories are flexible and can be created as needed.
 
-The todos directory is configurable via `.claude/agent-todos.local.md` (default: `docs/agent-todos/`).
+The todos directory is configurable via `.claude/agent-todos.local.json` (default: `docs/agent-todos/`).
 
 ```
 <todos-directory>/
@@ -165,7 +165,7 @@ When task is complete:
 
 ## Finding Tasks
 
-Replace `docs/agent-todos` with your configured todos directory if using Obsidian mode (see `.claude/agent-todos.local.md`).
+Replace `docs/agent-todos` with your configured todos directory if using Obsidian mode (see `.claude/agent-todos.local.json`).
 
 To list all open (not done) tasks:
 


### PR DESCRIPTION
## Summary

- Replace `.claude/agent-todos.local.md` (YAML frontmatter) with `.claude/agent-todos.local.json`
- Rename keys to camelCase: `todos_root` → `todosRoot`, `vault_root` → `vaultRoot`, `kanban_file` → `kanbanFile`
- Simplify parsing: `_read_fm_key` (awk) → `_read_json_key` (python3 heredoc)
- Bump version `0.3.0` → `0.4.0`

## Config file format

```json
{
  "todosRoot": "~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault>/agent-todos/<project>",
  "vaultRoot": "~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault>",
  "kanbanFile": "~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault>/agent-todos/<project>-kanban.md"
}
```

## Files changed

- `create-todo.sh`, `move-todos.sh`, `update-overview.sh` — new `_read_json_key` + `read_agent_todos_config()`
- `todo-migrate-to-obsidian/SKILL.md` — step 3 writes JSON config
- `docs/plugins/agent-todos.md` — config section updated
- All SKILL.md files referencing the config filename updated

## Test plan

- [ ] Without `.claude/agent-todos.local.json`: all scripts behave identically to v0.3.0
- [ ] With JSON config pointing to vault path: `create-todo.sh` writes to vault
- [ ] `update-overview.sh` generates Obsidian Kanban at `kanbanFile`
- [ ] Deleting the config file restores default `docs/agent-todos/` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)