### PR TITLE
fix(agent-todos): use valid YAML block scalars in skill descriptions …

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "agent-todos",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "source": "./plugins/agent-todos",
       "description": "Agent todo file management skills"
     },

--- a/docs/agent-todos/TODO_OVERVIEW.md
+++ b/docs/agent-todos/TODO_OVERVIEW.md
@@ -1,6 +1,6 @@
 # Todo Overview
 
-Generated on 2026-02-26 06:39:12 CET.
+Generated on 2026-02-26 14:19:40 CET.
 
 ## Todo Kanban
 
@@ -8,14 +8,14 @@ Generated on 2026-02-26 06:39:12 CET.
 %%{init: {"theme":"neutral"}}%%
 kanban
   new[New]
-    plugin-agent-todos-0017[make trello-vault path configurable]@{ ticket: plugin-agent-todos-0017 }
+
   ready[Ready]
     ideas-0001[Image Manipulation Skill with SIPs]@{ ticket: ideas-0001 }
     ideas-0002[Dev Toys CLI Skill]@{ ticket: ideas-0002 }
     ideas-0003[Skill to Search Skillsmp]@{ ticket: ideas-0003 }
     plugin-hugo-blog-0001[Hugo markdown linting skill]@{ ticket: plugin-hugo-blog-0001 }
   doing[Doing]
-
+    plugin-agent-todos-0017[make trello-vault path configurable]@{ ticket: plugin-agent-todos-0017 }
   done[Done]
     common-0001[Describe plugins in readme]@{ ticket: common-0001 }
     common-0002[describe obsidian import in readme]@{ ticket: common-0002 }
@@ -37,6 +37,7 @@ kanban
     plugin-agent-todos-0014[Todos have still h1 when they are created]@{ ticket: plugin-agent-todos-0014 }
     plugin-agent-todos-0015[Obsidian as primary todo store]@{ ticket: plugin-agent-todos-0015 }
     plugin-agent-todos-0016[Fix Obsidian Kanban settings block format]@{ ticket: plugin-agent-todos-0016 }
+    plugin-agent-todos-0018[improve interoperatablility]@{ ticket: plugin-agent-todos-0018 }
     plugin-skill-teaching-0000[Error when excecuting script]@{ ticket: plugin-skill-teaching-0000 }
 ```
 
@@ -50,7 +51,7 @@ kanban
 | ideas | [Image Manipulation Skill with SIPs](/docs/agent-todos/ideas/0001_image_manipulation_skill_with_sips.md) | ready |
 | ideas | [Dev Toys CLI Skill](/docs/agent-todos/ideas/0002_dev_toys_cli_skill.md) | ready |
 | ideas | [Skill to Search Skillsmp](/docs/agent-todos/ideas/0003_skill_to_search_skillsmp.md) | ready |
-| plugin-agent-todos | [make trello-vault path configurable](/docs/agent-todos/plugin-agent-todos/0017_make_trello_vault_path_configurable.md) | new |
+| plugin-agent-todos | [make trello-vault path configurable](/docs/agent-todos/plugin-agent-todos/0017_make_trello_vault_path_configurable.md) | doing |
 | plugin-agent-todos | [Change Todo Prefix To 4 Digits](/docs/agent-todos/plugin-agent-todos/DONE_0000_change_todo_prefix.md) | done |
 | plugin-agent-todos | [Error when installing Plugin](/docs/agent-todos/plugin-agent-todos/DONE_0001_error_when_installing.md) | done |
 | plugin-agent-todos | [Add status to todo](/docs/agent-todos/plugin-agent-todos/DONE_0002_add_status_to_todo.md) | done |
@@ -68,5 +69,6 @@ kanban
 | plugin-agent-todos | [Todos have still h1 when they are created](/docs/agent-todos/plugin-agent-todos/DONE_0014_todos_have_still_h1_when_they_are_created.md) | done |
 | plugin-agent-todos | [Obsidian as primary todo store](/docs/agent-todos/plugin-agent-todos/DONE_0015_obsidian_as_primary_todo_store.md) | done |
 | plugin-agent-todos | [Fix Obsidian Kanban settings block format](/docs/agent-todos/plugin-agent-todos/DONE_0016_fix_obsidian_kanban_settings_block_format.md) | done |
+| plugin-agent-todos | [improve interoperatablility](/docs/agent-todos/plugin-agent-todos/DONE_0018_improve_interoperatablility.md) | done |
 | plugin-hugo-blog | [Hugo markdown linting skill](/docs/agent-todos/plugin-hugo-blog/0001_hugo_markdown_linting_skill.md) | ready |
 | plugin-skill-teaching | [Error when excecuting script](/docs/agent-todos/plugin-skill-teaching/DONE_0000_error_when_excecuting_script.md) | done |

--- a/docs/agent-todos/plugin-agent-todos/DONE_0018_improve_interoperatablility.md
+++ b/docs/agent-todos/plugin-agent-todos/DONE_0018_improve_interoperatablility.md
@@ -1,0 +1,40 @@
+---
+title: "improve interoperatablility"
+status: done
+---
+
+## Context
+
+The skills in this plugin should also usable in other agentes like codes. but the have non-valid yaml in the frontmatter
+
+## Tasks
+
+- [x] use only valid yaml (see example)
+- [x] bump version with patch step
+
+## Progress, Decisions etc.
+
+### 2026-02-26: Implementation complete
+
+**What was done:**
+
+- Fixed 5 SKILL.md files with unquoted `description` values containing double-quote characters (invalid YAML)
+- Converted all 5 to `>` folded block scalar style, consistent with `todo-obsidian-icloud-import` and `todo-obsidian-import`
+- Files fixed: `todo-creation`, `todo-gh-issue-import`, `todo-migrate-to-obsidian`, `todo-moving`, `todo-overview`
+- 4 files were already valid: `todo-init`, `todo-obsidian-icloud-import`, `todo-obsidian-import`, `todo-processing`
+- Bumped `agent-todos` version `0.5.0` → `0.5.1` in `plugin.json` and `marketplace.json`
+
+## Example
+
+### Non Valid
+
+```yaml
+description: This skill should be used when the user asks to "create a todo", "add a todo", "new todo", "make a todo", "new task", "create a task", "add a task file", or wants to create a new agent todo file in the configured todos directory (default: docs/agent-todos/).
+```
+
+### Valid
+
+```yaml
+description: "This skill should be used when the user asks to `create a todo`, `add a todo`, `new todo`, `make a todo`, `new task`, `create a task`, `add a task file`, or
+wants to create a new agent todo file in the configured todos directory (default: docs/agent-todos/)."
+```

--- a/plugins/agent-todos/.claude-plugin/plugin.json
+++ b/plugins/agent-todos/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-todos",
   "description": "Agent todo file management skills",
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/plugins/agent-todos/skills/todo-creation/SKILL.md
+++ b/plugins/agent-todos/skills/todo-creation/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: todo-creation
-description: This skill should be used when the user asks to "create a todo", "add a todo", "new todo", "make a todo", "new task", "create a task", "add a task file", or wants to create a new agent todo file in the configured todos directory (default: docs/agent-todos/).
+description: >
+  This skill should be used when the user asks to "create a todo", "add a todo",
+  "new todo", "make a todo", "new task", "create a task", "add a task file", or
+  wants to create a new agent todo file in the configured todos directory
+  (default: docs/agent-todos/).
 allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
 invocation: user
 argument-hint: "[category] [title]"

--- a/plugins/agent-todos/skills/todo-gh-issue-import/SKILL.md
+++ b/plugins/agent-todos/skills/todo-gh-issue-import/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: todo-gh-issue-import
-description: Import open GitHub issues into local agent todo files. Use when the user asks to "import issues", "import from GitHub", "convert issues to todos", or wants to pull GitHub issues into the configured todos directory (default: docs/agent-todos/).
+description: >
+  Import open GitHub issues into local agent todo files. Use when the user asks
+  to "import issues", "import from GitHub", "convert issues to todos", or wants
+  to pull GitHub issues into the configured todos directory (default: docs/agent-todos/).
 compatibility: Requires gh CLI (https://cli.github.com/)
 allowed-tools: Bash, Read, Write, Edit, Skill, AskUserQuestion
 invocation: user

--- a/plugins/agent-todos/skills/todo-migrate-to-obsidian/SKILL.md
+++ b/plugins/agent-todos/skills/todo-migrate-to-obsidian/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: todo-migrate-to-obsidian
-description: This skill should be used when the user asks to "migrate todos to obsidian", "move agent todos to obsidian vault", "use obsidian as primary todo store", "move docs/agent-todos to obsidian", or wants to configure Obsidian as the primary store for this project's todos.
+description: >
+  This skill should be used when the user asks to "migrate todos to obsidian",
+  "move agent todos to obsidian vault", "use obsidian as primary todo store",
+  "move docs/agent-todos to obsidian", or wants to configure Obsidian as the
+  primary store for this project's todos.
 allowed-tools: Bash, Read, Write, Edit, AskUserQuestion, Skill
 invocation: user
 argument-hint: "[vault-name] [project-name]"

--- a/plugins/agent-todos/skills/todo-moving/SKILL.md
+++ b/plugins/agent-todos/skills/todo-moving/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: todo-moving
-description: This skill should be used when the user asks to "move todos", "move todo files between categories", "renumber open todos", "close numbering gaps in todo folders", or "avoid collisions with DONE todo numbers".
+description: >
+  This skill should be used when the user asks to "move todos", "move todo files
+  between categories", "renumber open todos", "close numbering gaps in todo
+  folders", or "avoid collisions with DONE todo numbers".
 version: 0.1.0
 allowed-tools: Bash, Read, Write, Edit
 invocation: user

--- a/plugins/agent-todos/skills/todo-overview/SKILL.md
+++ b/plugins/agent-todos/skills/todo-overview/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: todo-overview
-description: This skill should be used when the user asks to "create todo overview", "update todo overview", "generate TODO_OVERVIEW.md", "list all todos by status", "show todo table", "update kanban board", or wants a markdown table or Obsidian Kanban overview for the configured todos directory (default: docs/agent-todos).
+description: >
+  This skill should be used when the user asks to "create todo overview", "update
+  todo overview", "generate TODO_OVERVIEW.md", "list all todos by status", "show
+  todo table", "update kanban board", or wants a markdown table or Obsidian Kanban
+  overview for the configured todos directory (default: docs/agent-todos).
 allowed-tools: Bash, Read, Write, Edit
 invocation: user
 ---


### PR DESCRIPTION
…(v0.5.1)

Replace unquoted description values containing double-quote characters with folded block scalar (>) style in 5 SKILL.md files, making frontmatter parseable by strict YAML parsers (e.g. Codex). Affects todo-creation, todo-gh-issue-import, todo-migrate-to-obsidian, todo-moving, todo-overview.