### PR TITLE
fix(agent-todos): fix invalid YAML in todo-processing description (v0…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "agent-todos",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "source": "./plugins/agent-todos",
       "description": "Agent todo file management skills"
     },

--- a/plugins/agent-todos/.claude-plugin/plugin.json
+++ b/plugins/agent-todos/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-todos",
   "description": "Agent todo file management skills",
-  "version": "0.5.1"
+  "version": "0.5.2"
 }

--- a/plugins/agent-todos/skills/todo-processing/SKILL.md
+++ b/plugins/agent-todos/skills/todo-processing/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: todo-processing
-description: Work with AI agent todo files in the configured todos directory (default: docs/agent-todos)
+description: >
+  Work with AI agent todo files in the configured todos directory
+  (default: docs/agent-todos)
 invocation: none
 ---
 
@@ -90,13 +92,13 @@ Example: `DONE_0042_fix-soft-404-errors.md` → `Fix soft 404 errors`
 
 Tracks the lifecycle of a todo. Values and transitions:
 
-| Status     | Meaning                        | Transitions to     |
-|------------|--------------------------------|--------------------|
-| `new`      | Created but not yet fleshed out | `ready`           |
-| `ready`    | Has content, ready to work on  | `doing`           |
-| `doing`    | Currently being worked on      | `done`, `ready`   |
-| `done`     | Completed                      | `archived`        |
-| `archived` | Archived (reserved)            | —                  |
+| Status     | Meaning                         | Transitions to  |
+| ---------- | ------------------------------- | --------------- |
+| `new`      | Created but not yet fleshed out | `ready`         |
+| `ready`    | Has content, ready to work on   | `doing`         |
+| `doing`    | Currently being worked on       | `done`, `ready` |
+| `done`     | Completed                       | `archived`      |
+| `archived` | Archived (reserved)             | —               |
 
 - A file with the `DONE_` prefix should always have `status: done`.
 - When a file has meaningful content (problem description, tasks), use `ready`.


### PR DESCRIPTION
….5.2)

The `(default: docs/agent-todos)` plain scalar was parsed as a mapping by strict YAML parsers. Converted to > block scalar.