### PR TITLE
agent-todos: fix Obsidian kanban settings output and bump patch version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "agent-todos",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "source": "./plugins/agent-todos",
       "description": "Agent todo file management skills"
     },

--- a/docs/agent-todos/TODO_OVERVIEW.md
+++ b/docs/agent-todos/TODO_OVERVIEW.md
@@ -1,6 +1,6 @@
 # Todo Overview
 
-Generated on 2026-02-26 14:19:40 CET.
+Generated on 2026-02-26 17:33:46 CET.
 
 ## Todo Kanban
 
@@ -38,6 +38,7 @@ kanban
     plugin-agent-todos-0015[Obsidian as primary todo store]@{ ticket: plugin-agent-todos-0015 }
     plugin-agent-todos-0016[Fix Obsidian Kanban settings block format]@{ ticket: plugin-agent-todos-0016 }
     plugin-agent-todos-0018[improve interoperatablility]@{ ticket: plugin-agent-todos-0018 }
+    plugin-agent-todos-0019[enhance-todo-processing]@{ ticket: plugin-agent-todos-0019 }
     plugin-skill-teaching-0000[Error when excecuting script]@{ ticket: plugin-skill-teaching-0000 }
 ```
 
@@ -70,5 +71,6 @@ kanban
 | plugin-agent-todos | [Obsidian as primary todo store](/docs/agent-todos/plugin-agent-todos/DONE_0015_obsidian_as_primary_todo_store.md) | done |
 | plugin-agent-todos | [Fix Obsidian Kanban settings block format](/docs/agent-todos/plugin-agent-todos/DONE_0016_fix_obsidian_kanban_settings_block_format.md) | done |
 | plugin-agent-todos | [improve interoperatablility](/docs/agent-todos/plugin-agent-todos/DONE_0018_improve_interoperatablility.md) | done |
+| plugin-agent-todos | [enhance-todo-processing](/docs/agent-todos/plugin-agent-todos/DONE_0019_enhance_todo_processing.md) | done |
 | plugin-hugo-blog | [Hugo markdown linting skill](/docs/agent-todos/plugin-hugo-blog/0001_hugo_markdown_linting_skill.md) | ready |
 | plugin-skill-teaching | [Error when excecuting script](/docs/agent-todos/plugin-skill-teaching/DONE_0000_error_when_excecuting_script.md) | done |

--- a/docs/agent-todos/plugin-agent-todos/DONE_0019_enhance_todo_processing.md
+++ b/docs/agent-todos/plugin-agent-todos/DONE_0019_enhance_todo_processing.md
@@ -1,0 +1,43 @@
+---
+title: "enhance-todo-processing"
+status: done
+---
+
+## Context
+
+We want to enhance the `todo-processing` skill and script
+
+## Tasks
+
+- The skill should behave like that:
+  - if the user doe not give todo to process, present a list of all open todos to him (idealy he can choose interactivly)
+  - if this list has more then 5 open todo let the user first choose a category (idealy he can choose interactivly)
+  - if there are no open todos at all ask the user if he want's to create a new todo instead with the help of the `todo-creation` skill
+  - it the the user gives or selects a todo that has no numeric prefix add the next availabe prefix before the todo is processed
+  - if the given or selected tofo hat no or missing frontmatter data add it (use filename as title)
+- [x] The skill should behave like that:
+  - [x] if the user doe not give todo to process, present a list of all open todos to him (idealy he can choose interactivly)
+  - [x] if this list has more then 5 open todo let the user first choose a category (idealy he can choose interactivly)
+  - [x] if there are no open todos at all ask the user if he want's to create a new todo instead with the help of the `todo-creation` skill
+  - [x] it the the user gives or selects a todo that has no numeric prefix add the next availabe prefix before the todo is processed
+  - [x] if the given or selected tofo hat no or missing frontmatter data add it (use filename as title)
+- [x] After the skill has been improved bump the version of the plugin
+
+## Progress, Decisions etc.
+
+### 2026-02-26: Implemented interactive workflow and normalization
+
+**What was done:**
+
+- Changed `invocation: none` → `invocation: user`; added `allowed-tools`, `argument-hint`
+- Rewrote `description` in third-person trigger-phrase format matching sibling skills
+- Added `## Invocation` section with three-step workflow: identify todo (interactive if no arg), normalize (prefix + frontmatter), process
+- Fixed "Finding Tasks" section to use `<todos-dir>` placeholder instead of hardcoded `docs/agent-todos`
+- Made Step 3 handoff explicit: references `## Workflow` by name
+- Bumped plugin version `0.5.2` → `0.6.0` in `plugin.json` and `marketplace.json`
+
+**Decisions made:**
+
+- Category filter triggers at >5 todos (matches the task spec)
+- `Skill` tool used for `todo-creation` fallback (not a slash command)
+- `TODO-[DESCRIPTION].md` alternative format left documented as-is (reviewer noted it; normalization will apply a numeric prefix to it like any other unprefixed file)

--- a/plugins/agent-todos/.claude-plugin/plugin.json
+++ b/plugins/agent-todos/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-todos",
   "description": "Agent todo file management skills",
-  "version": "0.5.2"
+  "version": "0.6.0"
 }

--- a/plugins/agent-todos/skills/todo-processing/SKILL.md
+++ b/plugins/agent-todos/skills/todo-processing/SKILL.md
@@ -1,14 +1,70 @@
 ---
 name: todo-processing
 description: >
-  Work with AI agent todo files in the configured todos directory
-  (default: docs/agent-todos)
-invocation: none
+  This skill should be used when the user asks to "process a todo", "work on
+  a todo", "start a todo", "pick up a task", "handle todo 0042", provides a
+  path to a todo file to begin working on it, or asks "what should I work on
+  next" and todos exist in the configured todos directory
+  (default: docs/agent-todos).
+allowed-tools: Bash, Read, Write, Edit, AskUserQuestion, Glob, Grep, Skill
+invocation: user
+argument-hint: "[path/to/todo.md]"
 ---
 
 # todo-processing
 
 This skill describes how to work with todo files located in the configured todos directory (default: `docs/agent-todos/`). These files track tasks for AI agents working on this project.
+
+## Invocation
+
+### Step 1: Identify the Todo to Process
+
+**If a todo file path is provided as argument:**
+
+Use that file directly. Proceed to Step 2.
+
+**If no argument is given:**
+
+1. Read the configured todos directory from `.claude/agent-todos.local.json` (`todosRoot`), defaulting to `docs/agent-todos`.
+
+2. Find all open todos (non-`DONE_`, non-`TODO_OVERVIEW.md` `.md` files):
+
+   ```bash
+   find <todos-dir> -name "*.md" ! -name "DONE_*" ! -name "TODO_OVERVIEW.md" -type f | sort
+   ```
+
+3. **If no open todos exist:** Ask the user with `AskUserQuestion` whether they want to create a new todo. If yes, invoke the `todo-creation` skill via the `Skill` tool.
+
+4. **If more than 5 open todos exist:** First ask the user to pick a category using `AskUserQuestion`. List only subdirectory names that contain at least one open todo as the options.
+
+5. **Present the list:** Ask the user to select a todo using `AskUserQuestion`. Show the filename (without full path) as each option label. Use `multiSelect: false`.
+
+### Step 2: Validate and Normalize the Todo File
+
+**Missing numeric prefix:**
+
+If the selected or given filename does not start with 4 digits (`NNNN_`):
+
+1. Scan all files in the same category directory (including `DONE_` files) to find the highest numeric prefix.
+2. Assign the next 4-digit prefix.
+3. Rename the file using Bash `mv`.
+
+**Missing or incomplete frontmatter:**
+
+If the file has no YAML frontmatter (no `---` block at the top), or if `title` or `status` fields are absent:
+
+1. Derive the title from the filename:
+   - Strip `DONE_` prefix if present
+   - Strip the numeric prefix (e.g. `0001_`)
+   - Replace hyphens and underscores with spaces
+   - Capitalize the first letter
+2. Prepend or patch the frontmatter block with `title` and `status: new`.
+
+### Step 3: Process the Todo
+
+Continue with `## Workflow` > **Reading a Todo** below.
+
+---
 
 ## Directory Structure
 
@@ -16,7 +72,7 @@ Todo files are organized in category subdirectories. Categories are flexible and
 
 The todos directory is configurable via `.claude/agent-todos.local.json` (default: `docs/agent-todos/`).
 
-```
+```text
 <todos-directory>/
 ├── [category]/     # e.g., data, menu, misc, tags, thai-food-dict
 │   ├── 0001_task-description.md
@@ -167,22 +223,22 @@ When task is complete:
 
 ## Finding Tasks
 
-Replace `docs/agent-todos` with your configured todos directory if using Obsidian mode (see `.claude/agent-todos.local.json`).
+Read the configured todos directory from `.claude/agent-todos.local.json` (`todosRoot`), defaulting to `docs/agent-todos`. Substitute `<todos-dir>` below with that value.
 
 To list all open (not done) tasks:
 
 ```bash
-find docs/agent-todos -name "*.md" ! -name "DONE_*" -type f
+find <todos-dir> -name "*.md" ! -name "DONE_*" -type f
 ```
 
 To list all completed tasks:
 
 ```bash
-find docs/agent-todos -name "DONE_*.md" -type f
+find <todos-dir> -name "DONE_*.md" -type f
 ```
 
 To find tasks ready to be picked up (by frontmatter status):
 
 ```bash
-grep -rl "^status: ready" docs/agent-todos/
+grep -rl "^status: ready" <todos-dir>/
 ```


### PR DESCRIPTION
Summary
- fix Obsidian Kanban settings block output in todo overview generation
- remove fenced code wrapper from kanban settings so raw JSON is emitted
- bump agent-todos patch version in plugin and marketplace metadata
- complete and archive related agent todo entries and refresh TODO_OVERVIEW.md

Why
Obsidian Kanban expects raw JSON directly inside the kanban settings block. The previous generated output wrapped JSON in a fenced block and caused parsing errors.

Validation
- regenerated overview output and verified settings block format
- pushed branch and confirmed remote is up to date