### PR TITLE
agent-todos: bump to 0.6.1 and improve Obsidian migration flow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "agent-todos",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "source": "./plugins/agent-todos",
       "description": "Agent todo file management skills"
     },

--- a/docs/agent-todos/TODO_OVERVIEW.md
+++ b/docs/agent-todos/TODO_OVERVIEW.md
@@ -1,6 +1,6 @@
 # Todo Overview
 
-Generated on 2026-02-26 17:33:46 CET.
+Generated on 2026-02-26 21:12:26 CET.
 
 ## Todo Kanban
 
@@ -15,7 +15,7 @@ kanban
     ideas-0003[Skill to Search Skillsmp]@{ ticket: ideas-0003 }
     plugin-hugo-blog-0001[Hugo markdown linting skill]@{ ticket: plugin-hugo-blog-0001 }
   doing[Doing]
-    plugin-agent-todos-0017[make trello-vault path configurable]@{ ticket: plugin-agent-todos-0017 }
+
   done[Done]
     common-0001[Describe plugins in readme]@{ ticket: common-0001 }
     common-0002[describe obsidian import in readme]@{ ticket: common-0002 }
@@ -37,8 +37,10 @@ kanban
     plugin-agent-todos-0014[Todos have still h1 when they are created]@{ ticket: plugin-agent-todos-0014 }
     plugin-agent-todos-0015[Obsidian as primary todo store]@{ ticket: plugin-agent-todos-0015 }
     plugin-agent-todos-0016[Fix Obsidian Kanban settings block format]@{ ticket: plugin-agent-todos-0016 }
+    plugin-agent-todos-0017[make trello-vault path configurable]@{ ticket: plugin-agent-todos-0017 }
     plugin-agent-todos-0018[improve interoperatablility]@{ ticket: plugin-agent-todos-0018 }
     plugin-agent-todos-0019[enhance-todo-processing]@{ ticket: plugin-agent-todos-0019 }
+    plugin-agent-todos-0020[Plugin agent-todos: Migration to obsidian does not work at first attempt]@{ ticket: plugin-agent-todos-0020 }
     plugin-skill-teaching-0000[Error when excecuting script]@{ ticket: plugin-skill-teaching-0000 }
 ```
 
@@ -52,7 +54,6 @@ kanban
 | ideas | [Image Manipulation Skill with SIPs](/docs/agent-todos/ideas/0001_image_manipulation_skill_with_sips.md) | ready |
 | ideas | [Dev Toys CLI Skill](/docs/agent-todos/ideas/0002_dev_toys_cli_skill.md) | ready |
 | ideas | [Skill to Search Skillsmp](/docs/agent-todos/ideas/0003_skill_to_search_skillsmp.md) | ready |
-| plugin-agent-todos | [make trello-vault path configurable](/docs/agent-todos/plugin-agent-todos/0017_make_trello_vault_path_configurable.md) | doing |
 | plugin-agent-todos | [Change Todo Prefix To 4 Digits](/docs/agent-todos/plugin-agent-todos/DONE_0000_change_todo_prefix.md) | done |
 | plugin-agent-todos | [Error when installing Plugin](/docs/agent-todos/plugin-agent-todos/DONE_0001_error_when_installing.md) | done |
 | plugin-agent-todos | [Add status to todo](/docs/agent-todos/plugin-agent-todos/DONE_0002_add_status_to_todo.md) | done |
@@ -70,7 +71,9 @@ kanban
 | plugin-agent-todos | [Todos have still h1 when they are created](/docs/agent-todos/plugin-agent-todos/DONE_0014_todos_have_still_h1_when_they_are_created.md) | done |
 | plugin-agent-todos | [Obsidian as primary todo store](/docs/agent-todos/plugin-agent-todos/DONE_0015_obsidian_as_primary_todo_store.md) | done |
 | plugin-agent-todos | [Fix Obsidian Kanban settings block format](/docs/agent-todos/plugin-agent-todos/DONE_0016_fix_obsidian_kanban_settings_block_format.md) | done |
+| plugin-agent-todos | [make trello-vault path configurable](/docs/agent-todos/plugin-agent-todos/DONE_0017_make_obsidian_vault_path_configurable.md) | done |
 | plugin-agent-todos | [improve interoperatablility](/docs/agent-todos/plugin-agent-todos/DONE_0018_improve_interoperatablility.md) | done |
 | plugin-agent-todos | [enhance-todo-processing](/docs/agent-todos/plugin-agent-todos/DONE_0019_enhance_todo_processing.md) | done |
+| plugin-agent-todos | [Plugin agent-todos: Migration to obsidian does not work at first attempt](/docs/agent-todos/plugin-agent-todos/DONE_0020_plugin_agent_todos_migration_to_obsidian_does_not_work_at_fi.md) | done |
 | plugin-hugo-blog | [Hugo markdown linting skill](/docs/agent-todos/plugin-hugo-blog/0001_hugo_markdown_linting_skill.md) | ready |
 | plugin-skill-teaching | [Error when excecuting script](/docs/agent-todos/plugin-skill-teaching/DONE_0000_error_when_excecuting_script.md) | done |

--- a/docs/agent-todos/plugin-agent-todos/DONE_0017_make_obsidian_vault_path_configurable.md
+++ b/docs/agent-todos/plugin-agent-todos/DONE_0017_make_obsidian_vault_path_configurable.md
@@ -1,6 +1,6 @@
 ---
 title: "make trello-vault path configurable"
-status: doing
+status: done
 ---
 
 ## Context
@@ -13,4 +13,6 @@ For the `plugins/agent-todos/skills/todo-obsidian-icloud-import` skill we use a 
 - this should hacve a similar bevabioir like `plugins/agent-todos/skills/todo-obsidian-icloud-import` but the paths should also be configurabe like we do for the obsidian as primary todo storage
 - can we use the same settings?
 - plan before you build
-- bump version of plugin with minor
+- [x] create a new skill with script called `todo-obsidian-import`
+- [x] configurable paths via `vaultRoot` in `.claude/agent-todos.local.json`, falling back to iCloud Drive discovery
+- [x] bump version of plugin with minor (0.5.x → 0.6.0)

--- a/docs/agent-todos/plugin-agent-todos/DONE_0020_plugin_agent_todos_migration_to_obsidian_does_not_work_at_fi.md
+++ b/docs/agent-todos/plugin-agent-todos/DONE_0020_plugin_agent_todos_migration_to_obsidian_does_not_work_at_fi.md
@@ -1,0 +1,48 @@
+---
+title: 'Plugin agent-todos: Migration to obsidian does not work at first attempt'
+status: done
+---
+
+## Problem / Context
+
+Two issues encountered during `/todo-migrate-to-obsidian`:
+
+### 1. Skill ignored existing `.claude/agent-todos.local.json`
+
+The config file was already present with all three required values (`todosRoot`, `vaultRoot`, `kanbanFile`). The skill's workflow did not check for this file before starting vault discovery. Instead it proceeded to list vaults from iCloud Drive, which wasted steps and caused confusion.
+
+**Suggested fix:** At the start of the workflow, check for `.claude/agent-todos.local.json`. If it already contains `vaultRoot` and `todosRoot`, skip vault discovery and jump directly to step 2 (running the migration script).
+
+### 2. Migration script hardcoded to iCloud Drive path
+
+The vault was located at `~/Obsidian/vault-of-jens` (not under `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/`). The `migrate-to-obsidian.sh` script only checks the iCloud path and exited with an error:
+
+```
+Error: Vault not found: /Users/.../iCloud~md~obsidian/Documents/vault-of-jens
+```
+
+The workaround was to copy files manually using `cp` and then run `/todo-overview` directly.
+
+**Suggested fix:** When `vaultRoot` is already set in `.claude/agent-todos.local.json`, pass the resolved absolute path to the script and skip the iCloud vault lookup. Alternatively, add a `--vault-path` flag to the script that accepts an absolute path directly.
+
+## Tasks
+
+- [x] Check for existing `.claude/agent-todos.local.json` at the start of `todo-migrate-to-obsidian` skill; if `vaultRoot` and `todosRoot` are present, skip vault discovery
+- [x] Update `migrate-to-obsidian.sh` to use the configured `vaultRoot` directly instead of hardcoding the iCloud Drive path
+
+## Progress, Decisions etc.
+
+### 2026-02-26: Implemented config-check shortcut and absolute-path vault support
+
+**What was done:**
+
+- `SKILL.md`: Added new Step 1 "Check Existing Config" — reads `.claude/agent-todos.local.json`; if `vaultRoot` + `todosRoot` present, checks whether `docs/agent-todos/` still exists (if not → already migrated, stop); otherwise skips vault discovery and proceeds directly to migration script with `vaultRoot` as vault argument
+- `SKILL.md`: Step 2 now documents that absolute-path vault arguments (starting with `/` or `~`) must not be split on spaces; use `AskUserQuestion` for ambiguous cases
+- `migrate-to-obsidian.sh`: Added branch to use absolute paths directly as `VAULT_PATH`, bypassing iCloud Drive lookup; `~`-prefixed paths expanded via `${VAULT_NAME/#\~/$HOME}`
+- Renamed usage comment parameter label to `vault_name_or_path`
+- Updated `compatibility` frontmatter and macOS note to no longer require iCloud Drive specifically
+
+**Decisions made:**
+
+- Tilde expansion limited to `~/...` form only (not `~username/...`) — acceptable for this use case, documented via usage comment
+- Re-invocation with existing config + deleted source → fail cleanly with "already completed" message rather than silently re-copying nothing

--- a/plugins/agent-todos/.claude-plugin/plugin.json
+++ b/plugins/agent-todos/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-todos",
   "description": "Agent todo file management skills",
-  "version": "0.6.0"
+  "version": "0.6.1"
 }

--- a/plugins/agent-todos/skills/todo-migrate-to-obsidian/SKILL.md
+++ b/plugins/agent-todos/skills/todo-migrate-to-obsidian/SKILL.md
@@ -8,7 +8,7 @@ description: >
 allowed-tools: Bash, Read, Write, Edit, AskUserQuestion, Skill
 invocation: user
 argument-hint: "[vault-name] [project-name]"
-compatibility: macOS only (requires iCloud Drive with Obsidian vault)
+compatibility: macOS only (requires locally accessible Obsidian vault)
 ---
 
 # todo-migrate-to-obsidian
@@ -17,21 +17,36 @@ Migrate `docs/agent-todos/` to an Obsidian vault and configure the plugin to wri
 
 ## Workflow
 
-### 1. Gather Input
+### 1. Check Existing Config
+
+Read `.claude/agent-todos.local.json` in the project root, if it exists. Check for `vaultRoot` and `todosRoot` keys.
+
+**If both keys are present:**
+
+1. Check whether `docs/agent-todos/` still exists in the project root. If it does not, the migration was already completed and the source was deleted — inform the user and stop.
+2. Otherwise, the vault is already configured but migration can be re-run (e.g. to copy newly added todos). Skip vault discovery — use the existing `vaultRoot` value as the vault path argument to the migration script. Derive `project_name` from the `todosRoot` value (strip any trailing slash, then take the last path component, e.g. `my-project` from `.../agent-todos/my-project`). Proceed directly to Step 3 (Run Migration Script).
+
+**If the config is missing or incomplete:** Continue with Step 2.
+
+### 2. Gather Input
 
 Collect the vault name and project name. These may come from skill arguments or by asking the user.
 
 - **Vault name** — The Obsidian vault directory name under iCloud Drive's Obsidian folder. List available vaults:
+
   ```bash
   ls ~/Library/Mobile\ Documents/iCloud\~md\~obsidian/Documents/
   ```
+
 - **Project name** — Subdirectory name under `agent-todos/` in the vault. Defaults to the current project root directory name (e.g., `my-project`).
 
 If both values are provided as arguments (e.g., `/todo-migrate-to-obsidian vault-of-jens my-project`), parse the first word as vault name and the rest as project name.
 
+If the vault argument starts with `/` or `~` (an absolute path), do not split on spaces — treat the entire argument as the vault path. When in doubt, use AskUserQuestion to collect vault path and project name separately.
+
 If arguments are missing, ask the user using AskUserQuestion.
 
-### 2. Run Migration Script
+### 3. Run Migration Script
 
 ```bash
 bash <base_directory>/scripts/migrate-to-obsidian.sh "<project_root>" "<vault_name>" "<project_name>"
@@ -53,7 +68,7 @@ Parse the output lines to extract these three values.
 
 If the script exits with a non-zero status, report the error and stop.
 
-### 3. Write Config File
+### 4. Write Config File
 
 Create `.claude/agent-todos.local.json` in the project root using the three values from the script output:
 
@@ -67,11 +82,11 @@ Create `.claude/agent-todos.local.json` in the project root using the three valu
 
 Use the Write tool to create this file at `<project_root>/.claude/agent-todos.local.json`.
 
-### 4. Generate Initial Kanban Board
+### 5. Generate Initial Kanban Board
 
 Run `/todo-overview` to generate the initial Obsidian Kanban board at the configured `kanban_file` path. Confirm the output path from the script's stdout.
 
-### 5. Ask About Source Deletion
+### 6. Ask About Source Deletion
 
 Ask the user whether to delete `docs/agent-todos/` from the codebase:
 
@@ -87,7 +102,7 @@ If the user declines, leave the directory in place. Note that all todo skills wi
 
 ## Notes
 
-- macOS only — requires iCloud Drive with an Obsidian vault synced locally
+- macOS only — requires an Obsidian vault accessible on the local filesystem
 - Migration copies files — it does not move them; the user decides about source deletion
 - Sequential numbering and `DONE_` prefixes are preserved exactly
 - After migration, all skills (`/todo-creation`, `/todo-overview`, `/todo-moving`) use the vault path automatically via `.claude/agent-todos.local.json`

--- a/plugins/agent-todos/skills/todo-migrate-to-obsidian/scripts/migrate-to-obsidian.sh
+++ b/plugins/agent-todos/skills/todo-migrate-to-obsidian/scripts/migrate-to-obsidian.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # migrate-to-obsidian.sh — Copy docs/agent-todos/ to an Obsidian vault and
-# print the resulting config values for .claude/agent-todos.local.md.
+# print the resulting config values for .claude/agent-todos.local.json.
 #
 # Usage: migrate-to-obsidian.sh <project_root> <vault_name> [project_name]
 #
 #   project_root  — Root of the project (default: $PWD)
-#   vault_name    — Obsidian vault directory name under iCloud Drive
+#   vault_name_or_path — Absolute vault path (e.g. /Users/alice/Obsidian/vault) OR
+#                        bare vault name to look up under iCloud Drive
 #   project_name  — Subdirectory under agent-todos/ in the vault
 #                   (default: basename of project_root)
 #
@@ -29,17 +30,27 @@ fi
 
 # macOS check
 if [ "$(uname -s)" != "Darwin" ]; then
-  echo "Error: This script requires macOS with iCloud Drive." >&2
+  echo "Error: This script requires macOS." >&2
   exit 1
 fi
 
-ICLOUD_OBSIDIAN_BASE="$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"
-VAULT_PATH="$ICLOUD_OBSIDIAN_BASE/$VAULT_NAME"
+# Resolve vault path: absolute path used directly, otherwise look up under iCloud Drive
+if [[ "$VAULT_NAME" = /* ]]; then
+  VAULT_PATH="$VAULT_NAME"
+elif [[ "$VAULT_NAME" = ~* ]]; then
+  VAULT_PATH="${VAULT_NAME/#\~/$HOME}"
+else
+  ICLOUD_OBSIDIAN_BASE="$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"
+  VAULT_PATH="$ICLOUD_OBSIDIAN_BASE/$VAULT_NAME"
+fi
 
 if [ ! -d "$VAULT_PATH" ]; then
   echo "Error: Vault not found: $VAULT_PATH" >&2
-  echo "Available vaults:" >&2
-  ls "$ICLOUD_OBSIDIAN_BASE" >&2 2>/dev/null || true
+  if [[ "$VAULT_NAME" != /* ]] && [[ "$VAULT_NAME" != ~* ]]; then
+    ICLOUD_OBSIDIAN_BASE="$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents"
+    echo "Available vaults:" >&2
+    ls "$ICLOUD_OBSIDIAN_BASE" >&2 2>/dev/null || true
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- bump agent-todos patch version to 0.6.1 in plugin and marketplace metadata
- improve todo-migrate-to-obsidian workflow docs to reuse existing config when present
- update migrate-to-obsidian.sh to accept absolute and tilde-prefixed vault paths
- refresh todo tracking files and TODO_OVERVIEW to reflect completed migration-related tasks

## Why
This finalizes the current branch state with a patch release and fixes migration friction when vaults are not stored in the default iCloud Obsidian path.

## Validation
- branch pushed and up to date
- version fields updated consistently
- migration script and skill docs updated together