### PR TITLE
plugin/agent-todos: todo-init writes Agent Todos section to CLAUDE.md (v2.0.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "agent-todos",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "source": "./plugins/agent-todos",
       "description": "Agent todo file management skills"
     },

--- a/plugins/agent-todos/.claude-plugin/plugin.json
+++ b/plugins/agent-todos/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-todos",
   "description": "Agent todo file management skills",
-  "version": "2.0.1"
+  "version": "2.0.2"
 }

--- a/plugins/agent-todos/skills/todo-init/SKILL.md
+++ b/plugins/agent-todos/skills/todo-init/SKILL.md
@@ -24,6 +24,8 @@ If a config file is found, show the current settings and ask the user whether to
 
 **Upgrade path — missing `projectName`:** If the existing config is kept (user chooses not to reconfigure) but `projectName` is absent, ask: "Would you like to add a `projectName` to your config? This value is included in the `projects:` frontmatter of every new todo (e.g. `[[my-project]]`)." If yes, ask for the value and write it to the config file.
 
+**Upgrade path — missing CLAUDE.md section:** If the existing config is kept but no `## Agent Todos` section exists in `CLAUDE.md`, proceed to Step 6 to add it.
+
 ### Step 2: Determine Todo Store Path
 
 Ask the user where to store todos:
@@ -79,6 +81,37 @@ Ask the user which category subdirectories to create (multi-select). Suggest com
 - `content/` — Content creation and editing tasks
 
 Create the selected subdirectories inside `todosRoot`.
+
+### Step 6: Add Agent Todos Section to CLAUDE.md
+
+Check whether a `CLAUDE.md` file exists in the project root and whether it already contains an `## Agent Todos` section:
+
+```bash
+grep -q "## Agent Todos" CLAUDE.md 2>/dev/null && echo "exists" || echo "missing"
+```
+
+If the section is **missing**, append the following reference block to `CLAUDE.md`. Replace `<todosRoot>` with the actual configured path:
+
+```markdown
+## Agent Todos
+
+This project uses the **agent-todos** plugin to manage tasks as structured Markdown files.
+
+**IMPORTANT:** Always read `.agent-todos.local.json` before any todo operation. It defines `todosRoot` — the actual directory where todo files are stored. Do not fall back to `docs/agent-todos/` when this file is present.
+
+**Current todo store:** `<todosRoot>`
+
+**Skills:**
+
+- `/todo-creation [category] [title]` — create a new todo file
+- `/todo-processing [category/number]` — pick up and work on a todo
+- `/todo-gh-issue-import [category]` — import GitHub issues as todos
+- `/todo-moving` — renumber or move todos between categories
+```
+
+If `CLAUDE.md` does not exist, create it with only this section.
+
+If the section already exists, skip this step.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- `todo-init` now appends an `## Agent Todos` section to `CLAUDE.md` after setup (Step 6)
- Section template emphasizes reading `.agent-todos.local.json` first to prevent Claude from defaulting to `docs/agent-todos/`
- Upgrade path added: if existing config is found but the section is missing, Step 6 runs automatically
- Plugin bumped to `2.0.2`

## Test plan

- [ ] Run `/todo-init` in a project without a `CLAUDE.md` — file should be created with the section
- [ ] Run `/todo-init` in a project with an existing `CLAUDE.md` — section should be appended
- [ ] Run `/todo-init` when section already exists — no duplicate should be added

🤖 Generated with [Claude Code](https://claude.com/claude-code)