### PR TITLE
plugin/agent-todos: add worktree-aware config resolution (v2.0.2)

### DIFF
--- a/plugins/agent-todos/skills/todo-creation/SKILL.md
+++ b/plugins/agent-todos/skills/todo-creation/SKILL.md
@@ -35,7 +35,7 @@ Run the bundled script to create the todo file:
 bash <base_directory>/scripts/create-todo.sh "<category>" "<title>" "<project_root>"
 ```
 
-Where `<base_directory>` is the path shown in "Base directory for this skill:" at the top of the skill invocation, and `<project_root>` is the root of the current project.
+Where `<base_directory>` is the path shown in "Base directory for this skill:" at the top of the skill invocation, and `<project_root>` is the root of the current project. The script reads `.agent-todos.local.json` from `<project_root>` and falls back to the main worktree root automatically when operating inside a git worktree.
 
 The script:
 

--- a/plugins/agent-todos/skills/todo-creation/scripts/create-todo.sh
+++ b/plugins/agent-todos/skills/todo-creation/scripts/create-todo.sh
@@ -37,6 +37,17 @@ read_agent_todos_config() {
   local config_file="$PROJECT_ROOT/.agent-todos.local.json"
   TODOS_ROOT="$PROJECT_ROOT/docs/agent-todos"
   PROJECT_NAME=""
+
+  # Worktree fallback: if config not found in PROJECT_ROOT, check the main worktree root
+  if [ ! -f "$config_file" ]; then
+    local git_common_dir
+    git_common_dir=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null) || true
+    if [ -n "$git_common_dir" ]; then
+      [[ "$git_common_dir" = /* ]] || git_common_dir="$PROJECT_ROOT/$git_common_dir"
+      config_file="$(dirname "$git_common_dir")/.agent-todos.local.json"
+    fi
+  fi
+
   [ -f "$config_file" ] || return 0
   local v
   v="$(_read_json_key "$config_file" todosRoot)";    if [ -n "$v" ]; then TODOS_ROOT="${v/#\~/$HOME}"; fi

--- a/plugins/agent-todos/skills/todo-moving/scripts/move-todos.sh
+++ b/plugins/agent-todos/skills/todo-moving/scripts/move-todos.sh
@@ -23,6 +23,17 @@ _read_json_key() {
 read_agent_todos_config() {
   local config_file="$PROJECT_ROOT/.agent-todos.local.json"
   TODOS_ROOT="$PROJECT_ROOT/docs/agent-todos"
+
+  # Worktree fallback: if config not found in PROJECT_ROOT, check the main worktree root
+  if [ ! -f "$config_file" ]; then
+    local git_common_dir
+    git_common_dir=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null) || true
+    if [ -n "$git_common_dir" ]; then
+      [[ "$git_common_dir" = /* ]] || git_common_dir="$PROJECT_ROOT/$git_common_dir"
+      config_file="$(dirname "$git_common_dir")/.agent-todos.local.json"
+    fi
+  fi
+
   [ -f "$config_file" ] || return 0
   local v
   v="$(_read_json_key "$config_file" todosRoot)";  [ -n "$v" ] && TODOS_ROOT="${v/#\~/$HOME}"

--- a/plugins/agent-todos/skills/todo-processing/SKILL.md
+++ b/plugins/agent-todos/skills/todo-processing/SKILL.md
@@ -25,7 +25,7 @@ Use that file directly. Proceed to Step 2.
 
 **If no argument is given:**
 
-1. Read the configured todos directory from `.agent-todos.local.json` (`todosRoot`), defaulting to `docs/agent-todos`.
+1. Read the configured todos directory from `.agent-todos.local.json` (`todosRoot`), defaulting to `docs/agent-todos`. Look for this file in the project root. If not found there (e.g., when running inside a git worktree), run `git rev-parse --git-common-dir` to locate the main worktree's `.git` directory, then check for the config in its parent folder.
 
 2. Find all open todos (non-`DONE_`, non-`TODO_OVERVIEW.md` `.md` files):
 
@@ -233,7 +233,7 @@ When task is complete:
 
 ## Finding Tasks
 
-Read the configured todos directory from `.agent-todos.local.json` (`todosRoot`), defaulting to `docs/agent-todos`. Substitute `<todos-dir>` below with that value.
+Read the configured todos directory from `.agent-todos.local.json` (`todosRoot`), defaulting to `docs/agent-todos`. If the config is not found in the project root (e.g., inside a git worktree), run `git rev-parse --git-common-dir` and check the parent of that path. Substitute `<todos-dir>` below with the resolved value.
 
 To list all open (not done) tasks:
 


### PR DESCRIPTION
## Summary

- `create-todo.sh` and `move-todos.sh` now fall back to the main worktree root when `.agent-todos.local.json` is not found in `$PROJECT_ROOT` — fixes config resolution when Claude operates inside a git worktree
- Uses `git rev-parse --git-common-dir` to locate the main `.git` directory, then checks its parent for the config file
- `todo-processing/SKILL.md` and `todo-creation/SKILL.md` updated with the same worktree fallback instructions for Claude's own config reads

## Test plan

- [ ] Run `/todo-creation` from a git worktree where `.agent-todos.local.json` is in the main repo root — verify the correct `todosRoot` is used
- [ ] Run `/todo-processing` from the same worktree — verify it finds and lists todos from the configured store
- [ ] Verify no regression in the normal (non-worktree) case

🤖 Generated with [Claude Code](https://claude.com/claude-code)