### PR TITLE
Add office plugin and documentation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,6 +43,12 @@
       "version": "0.2.0",
       "source": "./plugins/cmux-tools",
       "description": "cmux browser workflow skills for opening, navigating, and screenshotting pages"
+    },
+    {
+      "name": "office",
+      "version": "0.1.0",
+      "source": "./plugins/office",
+      "description": "Microsoft Office file manipulation skills"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,10 @@ The plugin provides the following skills:
 
 - `cmux-browser-screenshooting` — Discovers or opens a `cmux` browser pane, navigates to a URL when needed, waits for load completion, and captures a screenshot to a local file
 
+**office** — Microsoft Office file manipulation skills:
+
+- `powerpoint-neutralizing` — Applies uniform PowerPoint styling by standardizing slide background, fonts, sizes, text color, and removing text shadows in a generated output file
+
 ## Installation
 
 ```bash
@@ -92,6 +96,7 @@ claude plugin install hugo-blog@ji-agent-skills --scope project
 claude plugin install obsidian@ji-agent-skills --scope project
 claude plugin install trello2obsidian@ji-agent-skills --scope project
 claude plugin install cmux-tools@ji-agent-skills --scope project
+claude plugin install office@ji-agent-skills --scope project
 ```
 
 ## Development Workflow

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ See the [Plugins Reference](https://code.claude.com/docs/en/plugins-reference) f
 | `obsidian`        | Obsidian vault, Kanban, and styling skills                 | [obsidian.md](docs/plugins/obsidian.md)               |
 | `trello2obsidian` | Convert Trello JSON exports into Obsidian-compatible notes | [trello2obsidian.md](docs/plugins/trello2obsidian.md) |
 | `cmux-tools`      | `cmux` browser opening, navigation, and screenshot skills  | [cmux-tools.md](docs/plugins/cmux-tools.md)           |
+| `office`          | Microsoft Office file manipulation skills                  | [office.md](docs/plugins/office.md)                   |
 
 Plugin-specific details, skill lists, and setup can be found under `docs/plugins/`.
 
@@ -49,4 +50,8 @@ claude plugin install trello2obsidian@ji-agent-skills --scope project
 
 ```bash
 claude plugin install cmux-tools@ji-agent-skills --scope project
+```
+
+```bash
+claude plugin install office@ji-agent-skills --scope project
 ```

--- a/docs/plugins/office.md
+++ b/docs/plugins/office.md
@@ -1,0 +1,30 @@
+# office
+
+`office` provides skills for manipulating Microsoft Office files, starting with PowerPoint presentation normalization.
+
+## What It Does
+
+- Standardizes `.pptx` slide backgrounds, fonts, and text color.
+- Removes text shadows from PowerPoint text content.
+- Writes a neutralized copy of the presentation next to the source file.
+- Supports overriding default colors, fonts, sizes, and output path via script flags.
+
+## Skills
+
+| Skill | Description |
+| --- | --- |
+| `/powerpoint-neutralizing` | Applies a consistent visual style to a PowerPoint file by normalizing background color, fonts, font sizes, text color, and text shadow settings. |
+
+## Typical Usage
+
+Install the plugin, then invoke the skill when you want Claude to:
+
+- Neutralize an existing `.pptx` deck before review or reuse.
+- Standardize slide styling across a presentation.
+- Produce a restyled copy without modifying the original input file.
+
+## Installation
+
+```bash
+claude plugin install office@ji-agent-skills --scope project
+```

--- a/plugins/office/.claude-plugin/plugin.json
+++ b/plugins/office/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "office",
+  "description": "Microsoft Office file manipulation skills",
+  "version": "0.1.0"
+}

--- a/plugins/office/skills/powerpoint-neutralizing/SKILL.md
+++ b/plugins/office/skills/powerpoint-neutralizing/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: powerpoint-neutralizing
+description: >
+  Use this skill when the user asks to "neutralize a pptx", "neutralize a presentation",
+  "standardize a PowerPoint", "normalize slide styling", or wants to apply uniform
+  background color, fonts, text color, and remove text shadows from a .pptx file.
+allowed-tools: Bash
+invocation: user
+argument-hint: "<input.pptx>"
+version: 0.1.0
+---
+
+# PowerPoint Neutralizer
+
+Applies uniform visual styling to a `.pptx` file:
+
+- All slide backgrounds → `#cccccc` (solid fill)
+- Title placeholders → Helvetica 18 pt
+- All other text → Helvetica 14 pt
+- All text color → `#000000`
+- Text shadows → removed
+
+All defaults are module-level constants in the bundled script and can be overridden via CLI flags.
+
+## Workflow
+
+### 1. Identify the input file
+
+Get the path to the `.pptx` file from the user argument or prompt if missing.
+
+### 2. Run the bundled script
+
+The script is bundled at `scripts/neutralize_pptx.py`. Run it from anywhere using the skill's resolved path:
+
+```bash
+# python-pptx available in active environment
+python3 .claude/skills/powerpoint-neutralizing/scripts/neutralize_pptx.py <input.pptx>
+
+# No active venv — use uv run
+uv run --with python-pptx python3 .claude/skills/powerpoint-neutralizing/scripts/neutralize_pptx.py <input.pptx>
+```
+
+Detect which to use:
+```bash
+python3 -c "import pptx" 2>/dev/null && echo "direct" || echo "uv"
+```
+
+Output is written to `<input>-neutralized.pptx` in the same directory as the input file.
+
+### 3. Override defaults (optional)
+
+If the user specifies different colors, fonts, or sizes, pass them as flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--bg-color HEX` | `#cccccc` | Slide background color |
+| `--font-color HEX` | `#000000` | All text color |
+| `--title-font NAME` | `Helvetica` | Title font family |
+| `--title-size N` | `18` | Title font size (pt) |
+| `--body-font NAME` | `Helvetica` | Body font family |
+| `--body-size N` | `14` | Body font size (pt) |
+| `-o PATH` | auto | Custom output path |
+
+Example with overrides:
+
+```bash
+uv run --with python-pptx python3 .claude/skills/powerpoint-neutralizing/scripts/neutralize_pptx.py \
+  input.pptx \
+  --bg-color "#f0f0f0" \
+  --font-color "#333333" \
+  --title-size 20 \
+  -o output.pptx
+```
+
+### 4. Report result
+
+Tell the user the full path of the output file.

--- a/plugins/office/skills/powerpoint-neutralizing/scripts/neutralize_pptx.py
+++ b/plugins/office/skills/powerpoint-neutralizing/scripts/neutralize_pptx.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Neutralize PPTX visual styling: uniform background, fonts, colors, no shadows."""
+
+import argparse
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.oxml.ns import qn
+from pptx.util import Pt
+
+# ── Defaults — override via CLI flags ──────────────────────────────────────────
+BG_COLOR = "#cccccc"
+FONT_COLOR = "#000000"
+TITLE_FONT = "Helvetica"
+TITLE_SIZE = 18
+BODY_FONT = "Helvetica"
+BODY_SIZE = 14
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def hex_to_rgb(hex_str: str) -> RGBColor:
+    h = hex_str.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def set_slide_background(slide, color: RGBColor) -> None:
+    fill = slide.background.fill
+    fill.solid()
+    fill.fore_color.rgb = color
+
+
+def remove_shadow(run) -> None:
+    rPr = run._r.get_or_add_rPr()
+    for tag in (qn("a:effectLst"), qn("a:effectDag")):
+        el = rPr.find(tag)
+        if el is not None:
+            rPr.remove(el)
+
+
+def is_title_shape(shape) -> bool:
+    try:
+        return shape.placeholder_format is not None and shape.placeholder_format.idx == 0
+    except Exception:
+        return False
+
+
+def neutralize(
+    input_path: str,
+    output_path: str,
+    bg_color: str,
+    font_color: str,
+    title_font: str,
+    title_size: int,
+    body_font: str,
+    body_size: int,
+) -> None:
+    prs = Presentation(input_path)
+    bg_rgb = hex_to_rgb(bg_color)
+    text_rgb = hex_to_rgb(font_color)
+
+    for slide in prs.slides:
+        set_slide_background(slide, bg_rgb)
+
+        for shape in slide.shapes:
+            if not shape.has_text_frame:
+                continue
+
+            title = is_title_shape(shape)
+            font_name = title_font if title else body_font
+            font_pt = Pt(title_size if title else body_size)
+
+            for para in shape.text_frame.paragraphs:
+                for run in para.runs:
+                    run.font.name = font_name
+                    run.font.size = font_pt
+                    run.font.color.rgb = text_rgb
+                    remove_shadow(run)
+
+    prs.save(output_path)
+    print(f"Saved: {output_path}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Neutralize PPTX styling")
+    p.add_argument("input", help="Input .pptx file")
+    p.add_argument("-o", "--output", help="Output path (default: <input>-neutralized.pptx)")
+    p.add_argument("--bg-color", default=BG_COLOR, metavar="HEX", help=f"Slide background color (default: {BG_COLOR})")
+    p.add_argument("--font-color", default=FONT_COLOR, metavar="HEX", help=f"Text color (default: {FONT_COLOR})")
+    p.add_argument("--title-font", default=TITLE_FONT, help=f"Title font name (default: {TITLE_FONT})")
+    p.add_argument("--title-size", type=int, default=TITLE_SIZE, help=f"Title font size in pt (default: {TITLE_SIZE})")
+    p.add_argument("--body-font", default=BODY_FONT, help=f"Body font name (default: {BODY_FONT})")
+    p.add_argument("--body-size", type=int, default=BODY_SIZE, help=f"Body font size in pt (default: {BODY_SIZE})")
+    args = p.parse_args()
+
+    stem = Path(args.input).stem
+    output = args.output or str(Path(args.input).with_stem(stem + "-neutralized"))
+
+    neutralize(
+        input_path=args.input,
+        output_path=output,
+        bg_color=args.bg_color,
+        font_color=args.font_color,
+        title_font=args.title_font,
+        title_size=args.title_size,
+        body_font=args.body_font,
+        body_size=args.body_size,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add the new office plugin metadata and PowerPoint neutralizing skill
- add plugin documentation under docs/plugins/office.md
- update top-level README and CLAUDE docs to list and install the plugin

## Testing
- manual documentation review only
