### PR TITLE
plugin/skill-teaching: add opencode, agents, gemini sync targets (v0.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "skill-teaching",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "source": "./plugins/skill-teaching",
       "description": "Share Claude Code skills with other AI agents"
     },

--- a/docs/plugins/skill-teaching.md
+++ b/docs/plugins/skill-teaching.md
@@ -5,7 +5,8 @@
 ## What It Does
 
 - Uses the Agent Skills open standard (published at [agentskills.io](https://agentskills.io/)).
-- Syncs project-scoped skills to other agents' expected directories (for example `.codex/skills`).
+- Syncs project-scoped skills to other agents' expected directories.
+- Supported targets: `codex` (`.codex/skills`), `opencode` (`.opencode/skills`), `agents` (`.agents/skills`), `gemini` (`.gemini/skills`).
 - Reads from `.claude/settings.json` and the local Claude plugin cache.
 
 ## Main Skill

--- a/plugins/skill-teaching/.claude-plugin/plugin.json
+++ b/plugins/skill-teaching/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "skill-teaching",
   "description": "Share Claude Code skills with other AI agents",
-  "version": "0.0.3"
+  "version": "0.1.0"
 }

--- a/plugins/skill-teaching/skills/skill-teaching/SKILL.md
+++ b/plugins/skill-teaching/skills/skill-teaching/SKILL.md
@@ -14,16 +14,19 @@ Synchronize Claude Code skills to other AI agents in the project. This enables k
 Determine the target agent where skills should be synced:
 
 - `codex` - OpenAI Codex agent (destination: `.codex/skills`)
+- `opencode` - OpenCode agent (destination: `.opencode/skills`)
+- `agents` - Generic agents folder (destination: `.agents/skills`)
+- `gemini` - Gemini agent (destination: `.gemini/skills`)
 
 ### Step 2: Execute Sync Script
 
 Run the sync script from the project root with the target agent identifier:
 
 ```bash
-bash <base_directory>/scripts/sync-skills.sh <target> <project_root>
+bash <base_directory>/scripts/sync-skills.sh <target>
 ```
 
-Where `<base_directory>` is the path shown in "Base directory for this skill:" output.
+Where `<base_directory>` is the path shown in "Base directory for this skill:" output. Pass a second argument `<project_root>` when running from a directory other than the project root (defaults to `$PWD`).
 
 ### Step 3: Verify Sync Results
 
@@ -40,6 +43,15 @@ The script performs these operations:
 ```bash
 # Sync all skills to Codex agent
 bash <base_directory>/scripts/sync-skills.sh codex
+
+# Sync all skills to OpenCode agent
+bash <base_directory>/scripts/sync-skills.sh opencode
+
+# Sync all skills to generic agents folder
+bash <base_directory>/scripts/sync-skills.sh agents
+
+# Sync all skills to Gemini agent
+bash <base_directory>/scripts/sync-skills.sh gemini
 ```
 
 ## Additional Resources
@@ -48,4 +60,4 @@ bash <base_directory>/scripts/sync-skills.sh codex
 
 The skill includes a utility script for skill synchronization:
 
-- **`scripts/sync-skills.sh`** - Executes the sync operation with manifest management
+- **`scripts/sync-skills.sh`** - Executes the sync operation with manifest management. Supported targets: `codex`, `opencode`, `agents`, `gemini`.

--- a/plugins/skill-teaching/skills/skill-teaching/scripts/sync-skills.sh
+++ b/plugins/skill-teaching/skills/skill-teaching/scripts/sync-skills.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Sync Claude Code skills to other AI agents
 # Usage: sync-skills.sh <target> [project-root]
-# Targets: codex
+# Targets: codex, opencode, agents, gemini
 
 PROJECT_ROOT="${2:-$PWD}"
 SETTINGS_FILE="$PROJECT_ROOT/.claude/settings.json"
@@ -14,7 +14,7 @@ TARGET="${1:-}"
 
 if [[ -z "$TARGET" ]]; then
   echo "Usage: sync-skills.sh <target>"
-  echo "Available targets: codex"
+  echo "Available targets: codex, opencode, agents, gemini"
   exit 1
 fi
 
@@ -23,9 +23,21 @@ case "$TARGET" in
     DEST="$PROJECT_ROOT/.codex/skills"
     MANIFEST="$DEST/.claude-synced-skills.json"
     ;;
+  opencode)
+    DEST="$PROJECT_ROOT/.opencode/skills"
+    MANIFEST="$DEST/.claude-synced-skills.json"
+    ;;
+  agents)
+    DEST="$PROJECT_ROOT/.agents/skills"
+    MANIFEST="$DEST/.claude-synced-skills.json"
+    ;;
+  gemini)
+    DEST="$PROJECT_ROOT/.gemini/skills"
+    MANIFEST="$DEST/.claude-synced-skills.json"
+    ;;
   *)
     echo "Error: Unknown target '$TARGET'"
-    echo "Available targets: codex"
+    echo "Available targets: codex, opencode, agents, gemini"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- Adds `opencode` (`.opencode/skills`), `agents` (`.agents/skills`), and `gemini` (`.gemini/skills`) as sync targets alongside the existing `codex` target
- Updates usage/error messages and script header comment to list all four targets
- Bumps plugin version from `0.0.3` to `0.1.0`
- Updates `docs/plugins/skill-teaching.md` and `SKILL.md` to document all targets

## Test plan

- [ ] Run `sync-skills.sh opencode` in a project — verify `.opencode/skills/` is created and populated
- [ ] Run `sync-skills.sh agents` — verify `.agents/skills/` is created and populated
- [ ] Run `sync-skills.sh gemini` — verify `.gemini/skills/` is created and populated
- [ ] Run `sync-skills.sh unknown` — verify error message lists all four targets
- [ ] Confirm manifest (`.claude-synced-skills.json`) is written correctly in each target directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)