### PR TITLE
plugin/cmux-tools: add cmux-browser-navigating skill (v0.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "cmux-tools",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "source": "./plugins/cmux-tools",
       "description": "cmux browser workflow skills for opening, navigating, and screenshotting pages"
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ The plugin provides the following skills:
 **cmux-tools** — Browser workflow skills for `cmux`:
 
 - `cmux-browser-screenshooting` — Discovers or opens a `cmux` browser pane, navigates to a URL when needed, waits for load completion, and captures a screenshot to a local file
+- `cmux-browser-navigating` — Navigates the `cmux` browser pane to a URL without taking a screenshot; opens a split browser if none exists
 
 **office** — Microsoft Office file manipulation skills:
 

--- a/docs/plugins/cmux-tools.md
+++ b/docs/plugins/cmux-tools.md
@@ -15,6 +15,7 @@
 | Skill | Description |
 | --- | --- |
 | `/cmux-browser-screenshooting` | Opens or reuses a `cmux` browser pane, navigates to a target URL when needed, waits for the page to load, and captures a screenshot. |
+| `/cmux-browser-navigating` | Navigates the `cmux` browser pane to a URL without taking a screenshot. Opens a split browser if none exists. |
 
 ## Typical Usage
 

--- a/plugins/cmux-tools/.claude-plugin/plugin.json
+++ b/plugins/cmux-tools/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "cmux-tools",
   "description": "cmux browser workflow skills for opening, navigating, and screenshotting pages",
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/plugins/cmux-tools/skills/cmux-browser-navigating/SKILL.md
+++ b/plugins/cmux-tools/skills/cmux-browser-navigating/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: cmux-browser-navigating
 description: This skill should be used when the user wants to navigate the cmux browser pane to a URL without taking a screenshot — for example when they say "just navigate", "navigate only", "point the browser at", "don't screenshot", or "navigate to URL without a screenshot". Use cmux-browser-screenshooting instead when a visual capture is also needed.
-version: 0.1.0
 ---
 
 # cmux Browser Navigating

--- a/plugins/cmux-tools/skills/cmux-browser-navigating/SKILL.md
+++ b/plugins/cmux-tools/skills/cmux-browser-navigating/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: cmux-browser-navigating
+description: This skill should be used when the user wants to navigate the cmux browser pane to a URL without taking a screenshot — for example when they say "just navigate", "navigate only", "point the browser at", "don't screenshot", or "navigate to URL without a screenshot". Use cmux-browser-screenshooting instead when a visual capture is also needed.
+version: 0.1.0
+---
+
+# cmux Browser Navigating
+
+Navigate the cmux browser to a URL without taking a screenshot. Opens a split browser if none exists.
+
+## Step 1 — Discover workspace and browser surface
+
+```bash
+WS=$(cmux identify | jq -r '.focused.workspace_ref')
+SURF=$(cmux rpc surface.list "{\"workspace_ref\":\"$WS\"}" | jq -r '[.surfaces[] | select(.type == "browser")] | first | .ref // empty')
+```
+
+- If `SURF` is non-empty → a browser pane exists.
+- If `SURF` is empty → no browser pane open.
+
+## Step 2 — Open or navigate
+
+### No browser exists → open one alongside the terminal
+
+```bash
+cmux browser open-split <url>
+```
+
+### Browser exists → navigate it and wait for load
+
+```bash
+cmux browser $SURF navigate <url>
+cmux browser $SURF wait --load-state complete
+```
+
+Done — no screenshot.
+
+## Notes
+
+- Prefer `open-split` over `open` to keep the terminal pane visible alongside the browser.
+- Surface refs change between sessions — always discover fresh, never hardcode.
+- If a screenshot is also needed after navigating, use `cmux-browser-screenshooting` instead.

--- a/plugins/cmux-tools/skills/cmux-browser-navigating/scripts/navigate.sh
+++ b/plugins/cmux-tools/skills/cmux-browser-navigating/scripts/navigate.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="${1:?Usage: navigate.sh <url>}"
+
+WS=$(cmux identify | jq -r '.focused.workspace_ref')
+SURF=$(cmux rpc surface.list "{\"workspace_ref\":\"$WS\"}" | jq -r '[.surfaces[] | select(.type == "browser")] | first | .ref // empty')
+
+if [ -z "$SURF" ]; then
+  cmux browser open-split "$URL"
+else
+  cmux browser "$SURF" navigate "$URL"
+  cmux browser "$SURF" wait --load-state complete
+fi

--- a/plugins/cmux-tools/skills/cmux-browser-screenshooting/SKILL.md
+++ b/plugins/cmux-tools/skills/cmux-browser-screenshooting/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: cmux-browser-screenshooting
 description: This skill should be used when the user asks to "take a screenshot", "screenshot the browser", "show me the browser", "capture the screen", "screenshot storybook", "open storybook in browser", "navigate to URL", "open URL in cmux", or wants to visually verify what is currently shown in a browser, open a new browser pane, or navigate an existing browser to a specific URL before screenshotting. Always use this skill instead of mcp__chrome-devtools__take_screenshot — cmux is token-efficient.
-version: 0.2.0
 ---
 
 # cmux Browser Screenshooting


### PR DESCRIPTION
## Summary

- Moves `cmux-browser-navigating` from a project-scoped skill into the `cmux-tools` plugin
- Skill navigates the cmux browser pane to a URL without taking a screenshot; opens a split browser if none exists
- Inline step-by-step commands (matching `cmux-browser-screenshooting` style) — no external script dependency
- Bumps `cmux-tools` from `0.2.0` to `0.3.0`
- Updates `CLAUDE.md`, `docs/plugins/cmux-tools.md`, and `marketplace.json`

## Test plan

- [ ] Run Step 1 discovery commands — verify `WS` and `SURF` resolve correctly
- [ ] With no browser open: run `cmux browser open-split <url>` — verify split browser opens
- [ ] With browser open: run navigate + wait commands — verify page loads at target URL
- [ ] Confirm no screenshot is taken (skill terminates after wait)
- [ ] Install plugin locally and verify skill appears: `claude plugin install cmux-tools@ji-agent-skills --scope project`

🤖 Generated with [Claude Code](https://claude.com/claude-code)