### PR TITLE
plugin/cmux-tools: add cmux-browser-chatgpting skill (v0.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "cmux-tools",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "source": "./plugins/cmux-tools",
       "description": "cmux browser workflow skills for opening, navigating, and screenshotting pages"
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ The plugin provides the following skills:
 
 - `cmux-browser-screenshooting` — Discovers or opens a `cmux` browser pane, navigates to a URL when needed, waits for load completion, and captures a screenshot to a local file
 - `cmux-browser-navigating` — Navigates the `cmux` browser pane to a URL without taking a screenshot; opens a split browser if none exists
+- `cmux-browser-chatgpting` — Sends a question to the ChatGPT browser surface open in cmux, submits via the send-button fallback chain (contenteditable textarea, no keyboard events), and captures the response as a screenshot
 
 **office** — Microsoft Office file manipulation skills:
 

--- a/plugins/cmux-tools/.claude-plugin/plugin.json
+++ b/plugins/cmux-tools/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "cmux-tools",
   "description": "cmux browser workflow skills for opening, navigating, and screenshotting pages",
-  "version": "0.3.0"
+  "version": "0.4.0"
 }

--- a/plugins/cmux-tools/skills/cmux-browser-chatgpting/SKILL.md
+++ b/plugins/cmux-tools/skills/cmux-browser-chatgpting/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: cmux-browser-chatgpting
+description: This skill should be used when the user asks to "ask ChatGPT", "frag ChatGPT", "send a question to ChatGPT", "schick das an ChatGPT", "frag GPT ob", "ask GPT something", or wants to type a question into the ChatGPT browser surface open in cmux and read the response.
+---
+
+# cmux Browser ChatGPT
+
+Send a question to the ChatGPT browser surface open in cmux and capture the response as a screenshot.
+
+## Workflow
+
+**Discovery:** Find the ChatGPT surface across all workspaces by scanning the cmux tree for `chatgpt.com`.
+
+**Interaction:** Fill the prompt input, submit, wait for the response, screenshot.
+
+Run the bundled script, passing the question as a single quoted argument:
+
+```bash
+bash <skill_base_dir>/scripts/ask-chatgpt.sh "<question>"
+```
+
+The script prints the surface ref it found and the path to the response screenshot.
+
+After the script completes, read the screenshot and relay ChatGPT's answer to the user.
+
+## Key Implementation Notes
+
+- ChatGPT uses a `contenteditable` div with id `#prompt-textarea` — use `cmux browser fill`, not `type`
+- `cmux browser eval` and `cmux browser press Enter` raise a JS exception on chatgpt.com — use the send-button click fallback chain instead
+- `cmux browser snapshot` returns almost nothing on chatgpt.com (heavy JS app) — screenshots are the only reliable way to read the response
+- Surface refs change between sessions — always discover fresh via `cmux tree --all`, never hardcode

--- a/plugins/cmux-tools/skills/cmux-browser-chatgpting/scripts/ask-chatgpt.sh
+++ b/plugins/cmux-tools/skills/cmux-browser-chatgpting/scripts/ask-chatgpt.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+QUESTION="${1:?Usage: ask-chatgpt.sh <question>}"
+
+# Find the ChatGPT surface across all workspaces by parsing the cmux tree
+SURF=$(cmux tree --all 2>&1 | grep "chatgpt.com" | grep -o "surface:[0-9]*" | head -1)
+
+if [ -z "$SURF" ]; then
+  echo "No ChatGPT browser surface found in any workspace." >&2
+  exit 1
+fi
+
+echo "Found ChatGPT on $SURF"
+
+# Fill the prompt input (ChatGPT uses #prompt-textarea)
+cmux browser "$SURF" fill "#prompt-textarea" "$QUESTION"
+
+# Submit — try each selector in sequence until one works
+cmux browser "$SURF" click "button[data-testid='send-button']" 2>/dev/null \
+  || cmux browser "$SURF" click "[aria-label*='Senden']" 2>/dev/null \
+  || cmux browser "$SURF" click "button[aria-label*='Send']"
+
+# Wait for the response to stream in, then screenshot
+sleep 4
+SCREENSHOT=$(cmux browser "$SURF" screenshot --json | grep '"path"' | sed 's/.*"path" : "\(.*\)".*/\1/')
+echo "Screenshot: $SCREENSHOT"


### PR DESCRIPTION
## Summary

- Adds `cmux-browser-chatgpting` skill — sends a question to the ChatGPT browser surface in cmux, submits via send-button fallback chain, and captures the response as a screenshot
- Bumps `cmux-tools` to v0.4.0 in `plugin.json` and `marketplace.json`
- Updates CLAUDE.md with the new skill entry

## Test plan

- [ ] Install `cmux-tools@ji-agent-skills` locally and invoke `cmux-browser-chatgpting` with a test question
- [ ] Verify screenshot is captured and response is relayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)