### PR TITLE
plugin/git-skills: add git-local-branch-cleaning skill (v0.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,6 +55,12 @@
       "version": "0.1.0",
       "source": "./plugins/figma",
       "description": "Figma Dev Mode MCP server integration — load Figma design tools on demand"
+    },
+    {
+      "name": "git-skills",
+      "version": "0.1.0",
+      "source": "./plugins/git-skills",
+      "description": "Git workflow skills for repository maintenance"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,10 @@ The plugin provides the following skills:
 
 - `powerpoint-neutralizing` — Applies uniform PowerPoint styling by standardizing slide background, fonts, sizes, text color, and removing text shadows in a generated output file
 
+**git-skills** — Git workflow skills for repository maintenance:
+
+- `git-local-branch-cleaning` — Deletes local (and matching remote) branches that are fully merged into `main`, have a gone remote tracking ref, or whose PR is merged/closed; fetches, shows candidates, and asks for confirmation before deleting
+
 **figma** — Figma Dev Mode MCP server integration for on-demand design tools:
 
 - `figma-mcp-setup` — Walks through enabling the Figma Dev Mode MCP server in the Figma desktop app (Preferences → Dev Mode → toggle), verifies connectivity via `curl`/`nc` on `127.0.0.1:3845`, and activates the plugin with `/plugin enable figma` + `/reload-plugins`. Avoids loading ~9 Figma tool schemas on every Claude Code session when not doing design work.
@@ -105,6 +109,7 @@ claude plugin install trello2obsidian@ji-agent-skills --scope project
 claude plugin install cmux-tools@ji-agent-skills --scope project
 claude plugin install office@ji-agent-skills --scope project
 claude plugin install figma@ji-agent-skills --scope project
+claude plugin install git-skills@ji-agent-skills --scope project
 ```
 
 ## Development Workflow

--- a/plugins/git-skills/.claude-plugin/plugin.json
+++ b/plugins/git-skills/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "git-skills",
+  "description": "Git workflow skills for repository maintenance",
+  "version": "0.1.0"
+}

--- a/plugins/git-skills/skills/git-local-branch-cleaning/SKILL.md
+++ b/plugins/git-skills/skills/git-local-branch-cleaning/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: git-local-branch-cleaning
+description: >
+  Delete local (and their corresponding remote) branches that have been merged into main,
+  have a deleted remote tracking ref, or whose PR is merged/closed. Use when the user asks
+  to "clean up local branches", "delete merged branches", "prune local branches", or "git cleanup".
+allowed-tools: Bash
+invocation: user
+---
+
+# git-local-branch-cleaning
+
+Clean up local branches that are no longer needed by running the bundled script.
+
+## Workflow
+
+Run the cleanup script:
+
+```bash
+bash <base_directory>/scripts/clean-branches.sh
+```
+
+Where `<base_directory>` is the path shown in "Base directory for this skill:" at the top of the skill invocation.
+
+The script will:
+1. Fetch and prune remote tracking refs
+2. Find branches in any of these states:
+   - Fully merged into `main`
+   - Remote tracking ref gone (remote branch was deleted)
+   - Corresponding PR is merged or closed (requires `gh` CLI)
+3. Display the list of candidate branches and ask for confirmation
+4. Delete confirmed branches locally with `git branch -d` / `git branch -D` and remove the matching remote branch if it still exists
+5. Report what was deleted and what was skipped

--- a/plugins/git-skills/skills/git-local-branch-cleaning/scripts/clean-branches.sh
+++ b/plugins/git-skills/skills/git-local-branch-cleaning/scripts/clean-branches.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "Fetching and pruning remote tracking refs..."
+git fetch --prune origin
+
+# Branches fully merged into main
+MERGED=$(git branch --merged main | grep -vE '^\*|^[[:space:]]*(main|master|develop)$' | sed 's/^[[:space:]]*//' || true)
+
+# Branches whose remote tracking is gone
+GONE=$(git branch -vv | grep ': gone]' | awk '{print $1}' | grep -vE '^(main|master|develop)$' || true)
+
+# Branches with a remote tracking ref but whose PR is merged or closed
+CLOSED_PR=""
+if command -v gh &>/dev/null; then
+  while IFS= read -r branch; do
+    [ -z "$branch" ] && continue
+    state=$(gh pr list --head "$branch" --state all --json state --jq '.[0].state // empty' 2>/dev/null || true)
+    if [[ "$state" == "MERGED" || "$state" == "CLOSED" ]]; then
+      CLOSED_PR="$CLOSED_PR"$'\n'"$branch"
+    fi
+  done < <(git branch -vv | grep -v ': gone]' | awk '/origin\// {print $1}' | grep -vE '^(main|master|develop)$')
+fi
+
+# Deduplicate
+CANDIDATES=$(printf '%s\n%s\n%s\n' "$MERGED" "$GONE" "$CLOSED_PR" | sort -u | grep -v '^$' || true)
+
+if [ -z "$CANDIDATES" ]; then
+  echo "Nothing to clean up — no merged or orphaned local branches found."
+  exit 0
+fi
+
+echo ""
+echo "Branches to delete:"
+echo "$CANDIDATES" | while read -r branch; do
+  echo "  - $branch"
+done
+echo ""
+read -rp "Delete these branches? [y/N] " confirm
+
+if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  echo "Aborted."
+  exit 0
+fi
+
+echo ""
+DELETED=()
+SKIPPED=()
+
+while IFS= read -r branch; do
+  [ -z "$branch" ] && continue
+  # Delete remote branch if it still exists
+  if git ls-remote --exit-code origin "$branch" &>/dev/null; then
+    git push origin --delete "$branch" 2>/dev/null || true
+  fi
+  if git branch -d "$branch" 2>/dev/null; then
+    DELETED+=("$branch")
+  else
+    # Likely squash/rebase merged — safe to force
+    if git branch -D "$branch" 2>/dev/null; then
+      DELETED+=("$branch (force)")
+    else
+      SKIPPED+=("$branch")
+    fi
+  fi
+done <<< "$CANDIDATES"
+
+if [ ${#DELETED[@]} -gt 0 ]; then
+  echo "Deleted:"
+  for b in "${DELETED[@]}"; do echo "  - $b"; done
+fi
+
+if [ ${#SKIPPED[@]} -gt 0 ]; then
+  echo "Skipped:"
+  for b in "${SKIPPED[@]}"; do echo "  - $b"; done
+fi


### PR DESCRIPTION
## Summary

- Adds new `git-skills` plugin (v0.1.0) with a single skill `git-local-branch-cleaning`
- Skill deletes local branches (and matching remotes) that are merged into `main`, have a gone remote tracking ref, or whose PR is merged/closed — with interactive confirmation before deletion
- Registers plugin in marketplace and documents it in CLAUDE.md

## Origin

Skill ported from `jobrad-gmbh/portal-landing-pages-infrastructure@chore/add-git-local-branch-cleaning-skill` — adapted script path to the plugin `<base_directory>/scripts/` convention and completed frontmatter (`allowed-tools`, `invocation`).

## Test plan

- [ ] `claude plugin install git-skills@ji-agent-skills --scope project` installs without error
- [ ] `/git-local-branch-cleaning` triggers the skill and runs `clean-branches.sh`
- [ ] Script lists merged/gone/closed-PR branches and prompts for confirmation
- [ ] Branches are deleted after confirming with `y`; aborted on `N`

🤖 Generated with [Claude Code](https://claude.com/claude-code)