### PR TITLE
plugin/cmux-tools: add cmux-browser-content-reading skill (v0.5.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,9 +40,9 @@
     },
     {
       "name": "cmux-tools",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "source": "./plugins/cmux-tools",
-      "description": "cmux browser workflow skills for opening, navigating, and screenshotting pages"
+      "description": "cmux browser workflow skills for opening, navigating, screenshotting, and reading page content"
     },
     {
       "name": "office",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ The plugin provides the following skills:
 - `cmux-browser-screenshooting` — Discovers or opens a `cmux` browser pane, navigates to a URL when needed, waits for load completion, and captures a screenshot to a local file
 - `cmux-browser-navigating` — Navigates the `cmux` browser pane to a URL without taking a screenshot; opens a split browser if none exists
 - `cmux-browser-chatgpting` — Sends a question to the ChatGPT browser surface open in cmux, submits via the send-button fallback chain (contenteditable textarea, no keyboard events), and captures the response as a screenshot
+- `cmux-browser-content-reading` — Reads text content from an already-open browser surface without navigating; discovers surface by title match, reads URL, and extracts text via `get text --selector`
 
 **office** — Microsoft Office file manipulation skills:
 

--- a/plugins/cmux-tools/.claude-plugin/plugin.json
+++ b/plugins/cmux-tools/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "cmux-tools",
   "description": "cmux browser workflow skills for opening, navigating, and screenshotting pages",
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/plugins/cmux-tools/skills/cmux-browser-content-reading/SKILL.md
+++ b/plugins/cmux-tools/skills/cmux-browser-content-reading/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: cmux-browser-content-reading
+description: This skill should be used when the user asks to "read the browser content", "read the cmux browser page", "what does the browser show", "what does the GitHub browser show", "what's on this page", "get the page text", "extract text from the browser", "summarize the page", "read the open tab", or wants to read/extract text from an already-open browser surface in cmux without navigating anywhere.
+---
+
+# cmux Browser Content Reading
+
+Read text content from an already-open browser surface in cmux without navigating to a new URL.
+
+## Step 1 — Discover workspace and browser surfaces
+
+```bash
+WS=$(cmux identify | jq -r '.focused.workspace_ref')
+```
+
+List all browser surfaces with their titles to decide which one to target:
+
+```bash
+cmux rpc surface.list "{\"workspace_ref\":\"$WS\"}" | jq -r '.surfaces[] | select(.type == "browser") | [.ref, .title] | @tsv'
+```
+
+### If the user named a specific tab
+
+Match by title keyword (case-insensitive):
+
+```bash
+SURF=$(cmux rpc surface.list "{\"workspace_ref\":\"$WS\"}" | \
+  jq -r '[.surfaces[] | select(.type == "browser" and (.title | test("KEYWORD"; "i")))] | first | .ref // empty')
+```
+
+Replace `KEYWORD` with the relevant word from the request (e.g. `"Seobility"`, `"GitHub"`, `"localhost"`).
+
+### If no specific tab was mentioned
+
+Fall back to the first available browser surface:
+
+```bash
+SURF=$(cmux rpc surface.list "{\"workspace_ref\":\"$WS\"}" | \
+  jq -r '[.surfaces[] | select(.type == "browser")] | first | .ref // empty')
+```
+
+If `SURF` is empty, no browser pane is open — inform the user and stop.
+
+## Step 2 — Check the current URL (optional)
+
+Confirm the right surface is selected before reading:
+
+```bash
+cmux browser $SURF url
+```
+
+## Step 3 — Read the text content
+
+`get text` requires an explicit `--selector` argument; there is no plain "dump the page" shortcut.
+
+### Full page body
+
+```bash
+cmux browser $SURF get text --selector body
+```
+
+### Narrow to a specific element
+
+When the page is long, target the relevant section to keep the output small:
+
+```bash
+# A results table
+cmux browser $SURF get text --selector "table"
+
+# Main content area
+cmux browser $SURF get text --selector "main"
+cmux browser $SURF get text --selector "#main-content"
+cmux browser $SURF get text --selector ".content"
+
+# A specific heading's section
+cmux browser $SURF get text --selector "article"
+```
+
+Prefer a narrower selector over `body` when the request targets a specific part of the page (e.g. "the results table", "the sidebar", "the error message").
+
+## Notes
+
+- Surface refs change between sessions — always discover fresh, never hardcode.
+- The `--selector` flag is mandatory for `get text`; omitting it will error.
+- If multiple browser surfaces match a title keyword, `jq first` picks the first match — list all surfaces first if the result looks wrong.
+- For visual confirmation, use `cmux-browser-screenshooting` instead of or in addition to this skill.
+- To navigate before reading, use `cmux-browser-navigating` first, then invoke this skill.


### PR DESCRIPTION
## Summary

- Adds `cmux-browser-content-reading` skill to the `cmux-tools` plugin
- Fills the gap between `cmux-browser-navigating` (navigate only) and `cmux-browser-screenshooting` (navigate + screenshot): reads text from an already-open browser surface without navigating
- Bumps `cmux-tools` to v0.5.0

## Skill behavior

- Discovers the focused workspace and lists all browser surfaces with titles
- Matches a surface by title keyword (case-insensitive) when the user names a specific tab; falls back to the first browser surface
- Reads the current URL via `cmux browser $SURF url`
- Extracts text via `cmux browser $SURF get text --selector <selector>` — documents that `--selector` is mandatory and guides narrowing to specific elements for token efficiency

## Origin

Sourced from a real ad-hoc workflow gap documented in issue #28 (now closed).

## Test plan

- [ ] `/cmux-browser-content-reading` triggers the skill
- [ ] Surface discovery by title keyword returns the correct ref
- [ ] `get text --selector body` returns page text
- [ ] Narrowing to a CSS selector (e.g. `table`) returns only that element's text

🤖 Generated with [Claude Code](https://claude.com/claude-code)