### PR TITLE
add install-skills.sh for Codex and other non-Claude-Code agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,8 @@ The plugin provides the following skills:
 
 ## Installation
 
+### Claude Code
+
 ```bash
 claude plugin marketplace add https://github.com/erich3000/ji-agent-skills
 claude plugin install agent-todos@ji-agent-skills --scope project
@@ -111,6 +113,21 @@ claude plugin install cmux-tools@ji-agent-skills --scope project
 claude plugin install office@ji-agent-skills --scope project
 claude plugin install figma@ji-agent-skills --scope project
 claude plugin install git-skills@ji-agent-skills --scope project
+```
+
+### Codex / other agents (no Claude Code required)
+
+`install-skills.sh` copies skills directly into any agent's skills directory:
+
+```bash
+# All skills → .codex/skills/ (default)
+curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash
+
+# Specific plugins only
+curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash -s -- cmux-tools git-skills
+
+# Custom target directory
+bash install-skills.sh --target .claude/skills
 ```
 
 ## Development Workflow

--- a/README.md
+++ b/README.md
@@ -15,43 +15,40 @@ See the [Plugins Reference](https://code.claude.com/docs/en/plugins-reference) f
 | `trello2obsidian` | Convert Trello JSON exports into Obsidian-compatible notes | [trello2obsidian.md](docs/plugins/trello2obsidian.md) |
 | `cmux-tools`      | `cmux` browser opening, navigation, and screenshot skills  | [cmux-tools.md](docs/plugins/cmux-tools.md)           |
 | `office`          | Microsoft Office file manipulation skills                  | [office.md](docs/plugins/office.md)                   |
+| `figma`           | Figma Dev Mode MCP server integration                      | [figma.md](docs/plugins/figma.md)                     |
+| `git-skills`      | Git workflow skills for repository maintenance             | [git-skills.md](docs/plugins/git-skills.md)           |
 
 Plugin-specific details, skill lists, and setup can be found under `docs/plugins/`.
 
 ## Installation
 
-### Add the Marketplace
+### Claude Code
 
 ```bash
 claude plugin marketplace add https://github.com/erich3000/ji-agent-skills
-```
 
-### Install the Plugins
-
-```bash
 claude plugin install agent-todos@ji-agent-skills --scope project
-```
-
-```bash
 claude plugin install skill-teaching@ji-agent-skills --scope project
-```
-
-```bash
 claude plugin install hugo-blog@ji-agent-skills --scope project
-```
-
-```bash
 claude plugin install obsidian@ji-agent-skills --scope project
-```
-
-```bash
 claude plugin install trello2obsidian@ji-agent-skills --scope project
-```
-
-```bash
 claude plugin install cmux-tools@ji-agent-skills --scope project
+claude plugin install office@ji-agent-skills --scope project
+claude plugin install figma@ji-agent-skills --scope project
+claude plugin install git-skills@ji-agent-skills --scope project
 ```
 
+### Codex / other agents (no Claude Code required)
+
+`install-skills.sh` copies skills into any agent's skills directory using only `bash` and `git`.
+
 ```bash
-claude plugin install office@ji-agent-skills --scope project
+# All skills → .codex/skills/
+curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash
+
+# Specific plugins only
+curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash -s -- cmux-tools git-skills
+
+# Custom target directory
+bash install-skills.sh --target .claude/skills
 ```

--- a/install-skills.sh
+++ b/install-skills.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Install skills from ji-agent-skills into any agent's skills directory.
+#
+# Usage:
+#   bash install-skills.sh                          # install all plugins → .codex/skills/
+#   bash install-skills.sh cmux-tools git-skills    # install specific plugins
+#   bash install-skills.sh --target .claude/skills  # custom target directory
+#   bash install-skills.sh cmux-tools --target ~/.codex/skills
+#
+# Remote usage (no clone needed):
+#   curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash
+#   curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash -s -- cmux-tools git-skills
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET=".codex/skills"
+PLUGINS=()
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      TARGET="$2"
+      shift 2
+      ;;
+    --target=*)
+      TARGET="${1#--target=}"
+      shift
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      PLUGINS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# When invoked via curl | bash, BASH_SOURCE[0] is not a real path — detect and fetch repo
+if [[ "$REPO_ROOT" == *"/dev/fd"* ]] || [[ ! -d "$REPO_ROOT/plugins" ]]; then
+  TMPDIR_CLONE=$(mktemp -d)
+  trap 'rm -rf "$TMPDIR_CLONE"' EXIT
+  echo "Cloning ji-agent-skills..."
+  git clone --depth 1 --quiet https://github.com/erich3000/ji-agent-skills.git "$TMPDIR_CLONE"
+  REPO_ROOT="$TMPDIR_CLONE"
+fi
+
+# Default to all plugins if none specified
+if [[ ${#PLUGINS[@]} -eq 0 ]]; then
+  while IFS= read -r dir; do
+    PLUGINS+=("$(basename "$dir")")
+  done < <(find "$REPO_ROOT/plugins" -mindepth 1 -maxdepth 1 -type d | sort)
+fi
+
+# Resolve target relative to CWD (not repo root)
+TARGET_ABS="$(pwd)/$TARGET"
+if [[ "$TARGET" == /* ]]; then
+  TARGET_ABS="$TARGET"
+fi
+
+INSTALLED=()
+SKIPPED=()
+
+for plugin in "${PLUGINS[@]}"; do
+  plugin_dir="$REPO_ROOT/plugins/$plugin"
+  if [[ ! -d "$plugin_dir/skills" ]]; then
+    echo "  [skip] $plugin — no skills directory found"
+    SKIPPED+=("$plugin")
+    continue
+  fi
+
+  while IFS= read -r skill_dir; do
+    skill_name="$(basename "$skill_dir")"
+    skill_md="$skill_dir/SKILL.md"
+    if [[ ! -f "$skill_md" ]]; then
+      continue
+    fi
+    dest_dir="$TARGET_ABS/$skill_name"
+    mkdir -p "$dest_dir"
+    cp "$skill_md" "$dest_dir/SKILL.md"
+    # Copy scripts/ and references/ if present
+    for sub in scripts references; do
+      if [[ -d "$skill_dir/$sub" ]]; then
+        cp -r "$skill_dir/$sub" "$dest_dir/"
+      fi
+    done
+    INSTALLED+=("$skill_name")
+  done < <(find "$plugin_dir/skills" -mindepth 1 -maxdepth 1 -type d | sort)
+done
+
+echo ""
+if [[ ${#INSTALLED[@]} -gt 0 ]]; then
+  echo "Installed ${#INSTALLED[@]} skill(s) to $TARGET:"
+  for s in "${INSTALLED[@]}"; do
+    echo "  + $s"
+  done
+fi
+
+if [[ ${#SKIPPED[@]} -gt 0 ]]; then
+  echo ""
+  echo "Skipped (plugin not found):"
+  for s in "${SKIPPED[@]}"; do
+    echo "  - $s"
+  done
+fi
+
+echo ""
+echo "Done. Skills are ready in: $TARGET"


### PR DESCRIPTION
## Summary

- Adds `install-skills.sh` at the repo root — a standalone bash script requiring only `bash` and `git`, no Claude Code needed
- Supports installing all plugins or a specific subset by name, with an optional `--target` flag for the output directory (default: `.codex/skills/`)
- Handles `curl | bash` invocation by auto-cloning the repo into a temp directory when not run locally
- Also copies `scripts/` and `references/` subdirectories alongside SKILL.md so bundled resources work
- Documents the new install method in both README.md and CLAUDE.md
- Fixes README plugin table and install commands (missing `figma` and `git-skills`)

## Usage

```bash
# All skills → .codex/skills/
curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash

# Specific plugins only
curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash -s -- cmux-tools git-skills

# Custom target directory
bash install-skills.sh --target .claude/skills
```

## Test plan

- [ ] `bash install-skills.sh` installs all 24 skills to `.codex/skills/`
- [ ] `bash install-skills.sh cmux-tools git-skills` installs only the 5 skills from those two plugins
- [ ] `bash install-skills.sh --target /tmp/out` writes to the custom path
- [ ] Unknown plugin name prints a skip message and continues without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)