### PR TITLE
install-skills.sh: auto-detect installed agents, install to all

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,19 +115,19 @@ claude plugin install figma@ji-agent-skills --scope project
 claude plugin install git-skills@ji-agent-skills --scope project
 ```
 
-### Codex / other agents (no Claude Code required)
+### Any agent (no Claude Code required)
 
-`install-skills.sh` copies skills directly into any agent's skills directory:
+`install-skills.sh` auto-detects installed agents (Codex, Claude Code, OpenCode, Gemini, …) and installs skills into each one. Requires only `bash` and `git`.
 
 ```bash
-# All skills → .codex/skills/ (default)
+# Auto-detect agents, install all plugins
 curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash
 
 # Specific plugins only
 curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash -s -- cmux-tools git-skills
 
-# Custom target directory
-bash install-skills.sh --target .claude/skills
+# Explicit target directory
+bash install-skills.sh --target .codex/skills
 ```
 
 ## Development Workflow

--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ claude plugin install figma@ji-agent-skills --scope project
 claude plugin install git-skills@ji-agent-skills --scope project
 ```
 
-### Codex / other agents (no Claude Code required)
+### Any agent (no Claude Code required)
 
-`install-skills.sh` copies skills into any agent's skills directory using only `bash` and `git`.
+`install-skills.sh` auto-detects installed agents (Codex, Claude Code, OpenCode, Gemini, …) and installs skills into each one. Requires only `bash` and `git`.
 
 ```bash
-# All skills → .codex/skills/
+# Auto-detect agents, install all plugins
 curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash
 
 # Specific plugins only
 curl -sSL https://raw.githubusercontent.com/erich3000/ji-agent-skills/main/install-skills.sh | bash -s -- cmux-tools git-skills
 
-# Custom target directory
-bash install-skills.sh --target .claude/skills
+# Explicit target directory
+bash install-skills.sh --target .codex/skills
 ```

--- a/install-skills.sh
+++ b/install-skills.sh
@@ -2,9 +2,9 @@
 # Install skills from ji-agent-skills into any agent's skills directory.
 #
 # Usage:
-#   bash install-skills.sh                          # install all plugins → .codex/skills/
-#   bash install-skills.sh cmux-tools git-skills    # install specific plugins
-#   bash install-skills.sh --target .claude/skills  # custom target directory
+#   bash install-skills.sh                          # auto-detect installed agents, install all plugins
+#   bash install-skills.sh cmux-tools git-skills    # install specific plugins only
+#   bash install-skills.sh --target .claude/skills  # install to a specific directory
 #   bash install-skills.sh cmux-tools --target ~/.codex/skills
 #
 # Remote usage (no clone needed):
@@ -14,18 +14,22 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET=".codex/skills"
+EXPLICIT_TARGET=""
 PLUGINS=()
+
+# Known agent CLI names and their corresponding skills directories (relative to project root)
+AGENT_NAMES=(codex claude opencode gemini agents)
+AGENT_SKILL_DIRS=(".codex/skills" ".claude/skills" ".opencode/skills" ".gemini/skills" ".agents/skills")
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --target)
-      TARGET="$2"
+      EXPLICIT_TARGET="$2"
       shift 2
       ;;
     --target=*)
-      TARGET="${1#--target=}"
+      EXPLICIT_TARGET="${1#--target=}"
       shift
       ;;
     -*)
@@ -55,57 +59,80 @@ if [[ ${#PLUGINS[@]} -eq 0 ]]; then
   done < <(find "$REPO_ROOT/plugins" -mindepth 1 -maxdepth 1 -type d | sort)
 fi
 
-# Resolve target relative to CWD (not repo root)
-TARGET_ABS="$(pwd)/$TARGET"
-if [[ "$TARGET" == /* ]]; then
-  TARGET_ABS="$TARGET"
-fi
+# Determine target directories
+CWD="$(pwd)"
+TARGETS=()
 
-INSTALLED=()
-SKIPPED=()
+if [[ -n "$EXPLICIT_TARGET" ]]; then
+  if [[ "$EXPLICIT_TARGET" == /* ]]; then
+    TARGETS+=("$EXPLICIT_TARGET")
+  else
+    TARGETS+=("$CWD/$EXPLICIT_TARGET")
+  fi
+else
+  # Auto-detect: include any agent whose CLI is installed or whose config dir exists
+  for i in "${!AGENT_NAMES[@]}"; do
+    agent="${AGENT_NAMES[$i]}"
+    rel_dir="${AGENT_SKILL_DIRS[$i]}"
+    config_dir="$CWD/${rel_dir%%/skills*}"  # e.g. .codex from .codex/skills
+    if command -v "$agent" &>/dev/null || [[ -d "$config_dir" ]]; then
+      TARGETS+=("$CWD/$rel_dir")
+    fi
+  done
 
-for plugin in "${PLUGINS[@]}"; do
-  plugin_dir="$REPO_ROOT/plugins/$plugin"
-  if [[ ! -d "$plugin_dir/skills" ]]; then
-    echo "  [skip] $plugin — no skills directory found"
-    SKIPPED+=("$plugin")
-    continue
+  if [[ ${#TARGETS[@]} -eq 0 ]]; then
+    echo "No known agents detected. Specify a target directory with --target." >&2
+    echo "Example: bash install-skills.sh --target .codex/skills" >&2
+    exit 1
   fi
 
-  while IFS= read -r skill_dir; do
-    skill_name="$(basename "$skill_dir")"
-    skill_md="$skill_dir/SKILL.md"
-    if [[ ! -f "$skill_md" ]]; then
+  echo "Detected agents:"
+  for t in "${TARGETS[@]}"; do
+    echo "  → $t"
+  done
+  echo ""
+fi
+
+# Install skills into a single target directory
+install_to() {
+  local target_abs="$1"
+  local installed=()
+  local skipped=()
+
+  for plugin in "${PLUGINS[@]}"; do
+    plugin_dir="$REPO_ROOT/plugins/$plugin"
+    if [[ ! -d "$plugin_dir/skills" ]]; then
+      skipped+=("$plugin")
       continue
     fi
-    dest_dir="$TARGET_ABS/$skill_name"
-    mkdir -p "$dest_dir"
-    cp "$skill_md" "$dest_dir/SKILL.md"
-    # Copy scripts/ and references/ if present
-    for sub in scripts references; do
-      if [[ -d "$skill_dir/$sub" ]]; then
-        cp -r "$skill_dir/$sub" "$dest_dir/"
-      fi
-    done
-    INSTALLED+=("$skill_name")
-  done < <(find "$plugin_dir/skills" -mindepth 1 -maxdepth 1 -type d | sort)
+
+    while IFS= read -r skill_dir; do
+      skill_name="$(basename "$skill_dir")"
+      skill_md="$skill_dir/SKILL.md"
+      [[ -f "$skill_md" ]] || continue
+      dest_dir="$target_abs/$skill_name"
+      mkdir -p "$dest_dir"
+      cp "$skill_md" "$dest_dir/SKILL.md"
+      for sub in scripts references; do
+        [[ -d "$skill_dir/$sub" ]] && cp -r "$skill_dir/$sub" "$dest_dir/"
+      done
+      installed+=("$skill_name")
+    done < <(find "$plugin_dir/skills" -mindepth 1 -maxdepth 1 -type d | sort)
+  done
+
+  if [[ ${#installed[@]} -gt 0 ]]; then
+    echo "Installed ${#installed[@]} skill(s) to $target_abs:"
+    for s in "${installed[@]}"; do echo "  + $s"; done
+  fi
+
+  if [[ ${#skipped[@]} -gt 0 ]]; then
+    echo "Skipped (plugin not found): ${skipped[*]}"
+  fi
+}
+
+for target in "${TARGETS[@]}"; do
+  install_to "$target"
+  echo ""
 done
 
-echo ""
-if [[ ${#INSTALLED[@]} -gt 0 ]]; then
-  echo "Installed ${#INSTALLED[@]} skill(s) to $TARGET:"
-  for s in "${INSTALLED[@]}"; do
-    echo "  + $s"
-  done
-fi
-
-if [[ ${#SKIPPED[@]} -gt 0 ]]; then
-  echo ""
-  echo "Skipped (plugin not found):"
-  for s in "${SKIPPED[@]}"; do
-    echo "  - $s"
-  done
-fi
-
-echo ""
-echo "Done. Skills are ready in: $TARGET"
+echo "Done."


### PR DESCRIPTION
## Summary

- `install-skills.sh` now auto-detects all installed agents (Codex, Claude Code, OpenCode, Gemini, and `.agents/`) and installs skills into each one in a single run
- Detection checks both CLI availability (`command -v`) and config directory presence
- `--target` still works for explicit single-directory installs
- Exits with a clear message if no agents are detected and no `--target` is given
- Fixed bash 3.2 compatibility (macOS default shell — no associative arrays)
- Updated README and CLAUDE.md framing from "Codex" to "any agent"

## Behaviour

```
$ bash install-skills.sh cmux-tools
Detected agents:
  → /project/.codex/skills
  → /project/.claude/skills
  → /project/.gemini/skills

Installed 4 skill(s) to /project/.codex/skills: ...
Installed 4 skill(s) to /project/.claude/skills: ...
Installed 4 skill(s) to /project/.gemini/skills: ...

Done.
```

## Test plan

- [ ] Running without `--target` detects all agents present in the environment
- [ ] Running with `--target` installs only to that path
- [ ] No agents detected → prints error and exits 1
- [ ] Works via `curl | bash` (auto-clones repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)