### PR TITLE
plugin/cmux-tools: add cmux-file-previewing skill (v0.6.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,9 +40,9 @@
     },
     {
       "name": "cmux-tools",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "source": "./plugins/cmux-tools",
-      "description": "cmux browser workflow skills for opening, navigating, screenshotting, and reading page content"
+      "description": "cmux workflow skills for opening, navigating, screenshotting, reading page content, and previewing files"
     },
     {
       "name": "office",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ The plugin provides the following skills:
 - `cmux-browser-navigating` — Navigates the `cmux` browser pane to a URL without taking a screenshot; opens a split browser if none exists
 - `cmux-browser-chatgpting` — Sends a question to the ChatGPT browser surface open in cmux, submits via the send-button fallback chain (contenteditable textarea, no keyboard events), and captures the response as a screenshot
 - `cmux-browser-content-reading` — Reads text content from an already-open browser surface without navigating; discovers surface by title match, reads URL, and extracts text via `get text --selector`
+- `cmux-file-previewing` — Opens one or more files as viewer tabs in a dedicated cmux pane; reuses the same pane across calls via a cached pane ref so repeated previews accumulate as tabs instead of scattering across the workspace
 
 **office** — Microsoft Office file manipulation skills:
 

--- a/plugins/cmux-tools/.claude-plugin/plugin.json
+++ b/plugins/cmux-tools/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "cmux-tools",
-  "description": "cmux browser workflow skills for opening, navigating, and screenshotting pages",
-  "version": "0.5.0"
+  "description": "cmux workflow skills for opening, navigating, screenshotting, and previewing files",
+  "version": "0.6.0"
 }

--- a/plugins/cmux-tools/skills/cmux-file-previewing/SKILL.md
+++ b/plugins/cmux-tools/skills/cmux-file-previewing/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: cmux-file-previewing
+description: This skill should be used when the user asks to "preview this file", "open file in cmux", "show file in preview pane", "preview these files", or "open [filename] in the preview pane", or wants to open one or more files as viewer tabs in a dedicated cmux pane. Reuses the same pane across calls by caching the pane ref — repeated previews accumulate as tabs in one pane instead of scattering across the workspace.
+---
+
+# cmux File Previewing
+
+Open one or more files as viewer tabs in a dedicated cmux pane. Reuses the same pane across calls by caching the pane ref — repeated previews accumulate as tabs in one pane instead of scattering across the workspace.
+
+## Step 1 — Run the bundled script
+
+The skill ships `scripts/open_file_preview.sh`. The base directory is printed in the skill header when the skill loads. Run:
+
+```bash
+bash <skill-base-dir>/scripts/open_file_preview.sh <file> [<file2> ...]
+```
+
+Paths can be relative or absolute — the script resolves them internally. Pass all files in a single call when previewing multiple files; each becomes a new tab in the same pane.
+
+If the base directory is not printed in the skill header, locate the script by searching the plugin cache:
+
+```bash
+find ~/.claude/plugins/cache -name "open_file_preview.sh" 2>/dev/null | head -1
+```
+
+## What the script does
+
+1. Reads the cached pane ref from `scripts/.pane_ref` (next to the script).
+2. Validates the cached ref is still live: `cmux list-panes | grep -qF <ref>`.
+3. **Pane valid** — opens each file in that pane: `cmux open --pane <ref> <file> --focus true`.
+4. **Pane invalid/missing** — creates a new pane (`cmux new-pane --direction right --focus false`), extracts the ref from the output, writes it to `scripts/.pane_ref`, then opens the file(s) there.
+
+## Inline steps (without the script)
+
+When the script is unavailable, replicate the logic manually. Use `~/.cmux-file-preview-pane-ref` as the state file — it is usable without knowing the skill base directory:
+
+```bash
+STATE="$HOME/.cmux-file-preview-pane-ref"
+PANE=""
+
+# Read and validate cache
+if [ -f "$STATE" ]; then
+  CACHED="$(cat "$STATE")"
+  if cmux list-panes | grep -qF "$CACHED"; then
+    PANE="$CACHED"
+  fi
+fi
+
+# Create pane if needed
+if [ -z "$PANE" ]; then
+  OUT="$(cmux new-pane --direction right --focus false)"
+  PANE="$(printf '%s' "$OUT" | grep -oE 'pane:[0-9]+')"
+  printf '%s' "$PANE" > "$STATE"
+fi
+
+# Open each file (resolve to absolute path first)
+ABS="$(cd "$(dirname <file>)" && pwd)/$(basename <file>)"
+cmux open --pane "$PANE" "$ABS" --focus true
+```
+
+## Notes
+
+- **State file** — The script uses `scripts/.pane_ref` next to itself; the inline path uses `~/.cmux-file-preview-pane-ref`. Both persist across agent turns. Self-healing: a stale ref (pane closed manually or after a cmux restart) is detected on the next call and a fresh pane is created automatically.
+- **Pane refs** — Pane refs do not survive cmux restarts; the stale-ref detection handles this transparently. Never hardcode a pane ref.
+- **Session caveat** — Pane refs don't survive cmux restarts; the stale-ref path handles this transparently.
+- **Focus** — The new pane is created without stealing focus (`--focus false`); each opened file receives focus as it opens (`--focus true`).
+- **Multiple files** — Pass all files in one script call. The pane ref is determined once; subsequent files open into the same pane as additional tabs.
+- **Viewer tabs vs terminal** — Unlike `cmux-webp-previewing` (which uses terminal surfaces + `cmux send`), this skill uses `cmux open` which creates native viewer tabs. The `--type` flag is not needed; cmux infers the viewer type from the file extension. The `cmux open` flag contract: `open <path-or-url>... [--pane <id|ref|index>] [--focus <true|false>]` (confirmed from `cmux --help`).

--- a/plugins/cmux-tools/skills/cmux-file-previewing/scripts/open_file_preview.sh
+++ b/plugins/cmux-tools/skills/cmux-file-previewing/scripts/open_file_preview.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $(basename "$0") file [file2 ...]" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_FILE="$SCRIPT_DIR/.pane_ref"
+
+pane_exists() {
+  cmux list-panes | grep -qF "$1"
+}
+
+PANE=""
+if [ -f "$STATE_FILE" ]; then
+  CACHED="$(cat "$STATE_FILE")"
+  if [ -n "$CACHED" ] && pane_exists "$CACHED"; then
+    PANE="$CACHED"
+  fi
+fi
+
+if [ -z "$PANE" ]; then
+  OUT="$(cmux new-pane --direction right --focus false)"
+  PANE="$(printf '%s' "$OUT" | grep -oE 'pane:[0-9]+')"
+  printf '%s' "$PANE" > "$STATE_FILE"
+fi
+
+for FILE in "$@"; do
+  ABS="$(cd "$(dirname "$FILE")" && pwd)/$(basename "$FILE")"
+  cmux open --pane "$PANE" "$ABS" --focus true
+done


### PR DESCRIPTION
## Summary

- Adds `cmux-file-previewing` skill to the `cmux-tools` plugin
- Uses a state-file pane-remembering pattern (modeled on `cmux-webp-previewing`) — caches the pane ref in `scripts/.pane_ref`, validates liveness via `cmux list-panes | grep -qF`, reuses or auto-recreates the pane
- Ships a bundled `scripts/open_file_preview.sh` and an inline fallback in SKILL.md for when the script isn't available
- Bumps cmux-tools to v0.6.0

## Test plan

- [ ] Run `bash plugins/cmux-tools/skills/cmux-file-previewing/scripts/open_file_preview.sh <somefile>` with cmux running — verify a new pane opens with the file
- [ ] Run again with a second file — verify it opens as a new tab in the same pane (not a new pane)
- [ ] Close the preview pane manually, run again — verify a fresh pane is created (stale-ref self-healing)
- [ ] Verify trigger phrases load the skill: "preview this file", "open file in cmux"

🤖 Generated with [Claude Code](https://claude.com/claude-code)